### PR TITLE
Improve sync status display

### DIFF
--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -133,6 +133,9 @@ class AgendumApp(App):
         self._config = config  # resolved in on_mount if None
         self._task_rows: list[dict | None] = []  # None = section header
         self._last_sync: datetime | None = None
+        self._sync_in_progress = False
+        self._sync_error: str | None = None
+        self._sync_spinner_frame = 0
         self._app_focused = True
         self._modal_task: dict | None = None
 
@@ -185,6 +188,7 @@ class AgendumApp(App):
         # Run initial sync immediately, then on interval
         self._start_sync()
         self.set_interval(self._config.sync_interval, self._start_sync)
+        self.set_interval(0.25, self._tick_initial_sync_spinner)
         self.set_interval(10, self._update_status_bar)
 
     def on_resize(self) -> None:
@@ -246,36 +250,34 @@ class AgendumApp(App):
                 table.add_row(dot, status_text, title, author, repo, link)
                 self._task_rows.append(task)
 
-        # Update status bar
-        total = len(tasks)
-        sync_info = ""
-        if self._last_sync:
-            age = (datetime.now(timezone.utc) - self._last_sync).total_seconds()
-            if age < 60:
-                sync_info = f" | synced {int(age)}s ago"
-            else:
-                sync_info = f" | synced {int(age // 60)}m ago"
-        bar = self.query_one("#status-bar", Static)
-        bar.update(f" agendum — {total} tasks{sync_info}")
+        self._update_status_bar()
 
     def _update_status_bar(self) -> None:
-        """Update the status bar with current sync age."""
+        """Update the status bar with current sync state."""
         tasks = get_active_tasks(self.db_path)
         unseen = sum(1 for t in tasks if not t["seen"])
-        sync_ago = ""
-        if self._last_sync:
-            delta = int((datetime.now(timezone.utc) - self._last_sync).total_seconds())
-            if delta < 60:
-                sync_ago = f"synced {delta}s ago"
-            else:
-                sync_ago = f"synced {delta // 60}m ago"
-        else:
-            sync_ago = "not yet synced"
         total = len(tasks)
         unseen_str = f" — {unseen} new" if unseen else ""
+        sync_status = self._format_sync_status()
         self.query_one("#status-bar", Static).update(
-            f"agendum — {sync_ago} — {total} tasks{unseen_str}"
+            f"agendum — {sync_status} — {total} tasks{unseen_str}"
         )
+
+    def _format_sync_status(self) -> str:
+        if self._sync_error:
+            return f"🟡 sync status ({self._sync_error})"
+        if self._last_sync:
+            return "🟢 sync status"
+        if self._sync_in_progress:
+            frame = "|/-\\"[self._sync_spinner_frame % 4]
+            return f"initial sync starting {frame}"
+        return "initial sync pending"
+
+    def _tick_initial_sync_spinner(self) -> None:
+        if not self._sync_in_progress or self._last_sync is not None or self._sync_error:
+            return
+        self._sync_spinner_frame += 1
+        self._update_status_bar()
 
     # ── navigation ───────────────────────────────────────────────────
 
@@ -358,10 +360,14 @@ class AgendumApp(App):
 
     def _start_sync(self) -> None:
         """Kick off a sync in a background worker."""
-        self.query_one("#status-bar", Static).update("agendum — syncing…")
+        if self._sync_in_progress:
+            return
+        self._sync_in_progress = True
+        self._sync_spinner_frame = 0
+        self._update_status_bar()
         self.run_worker(self._do_sync(), exclusive=True, group="sync")
 
-    async def _do_sync(self) -> tuple[int, bool]:
+    async def _do_sync(self) -> tuple[int, bool, str | None]:
         """Run sync in a worker thread — does not touch UI."""
         return await run_sync(self._db_path, self._config)
 
@@ -369,16 +375,28 @@ class AgendumApp(App):
         """Handle sync worker completion."""
         if event.worker.group != "sync":
             return
+        self._sync_in_progress = False
         if event.state != WorkerState.SUCCESS:
             if event.state == WorkerState.ERROR:
                 log.exception("Sync failed: %s", event.worker.error)
+                self._sync_error = self._format_sync_error(event.worker.error)
+                self._update_status_bar()
             return
-        changes, attention = event.worker.result
+        changes, attention, error = event.worker.result
         self._last_sync = datetime.now(timezone.utc)
+        self._sync_error = error
         self.refresh_table()
         self._update_status_bar()
         if attention and not self._app_focused:
             self.bell()
+
+    def _format_sync_error(self, error: BaseException | None) -> str:
+        if error is None:
+            return "unknown sync error"
+        message = str(error).strip()
+        if not message:
+            return error.__class__.__name__
+        return message
 
     def action_force_sync(self) -> None:
         self._start_sync()

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -71,19 +71,19 @@ def diff_tasks(existing: list[dict], incoming: list[dict]) -> SyncResult:
     return result
 
 
-async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool]:
+async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str | None]:
     """
     Execute a full sync cycle.
-    Returns (changes_count, has_attention_items).
+    Returns (changes_count, has_attention_items, error_message).
     """
     if not config.orgs and not config.repos:
         log.warning("No orgs or repos configured — skipping sync")
-        return 0, False
+        return 0, False, None
 
     gh_user = await gh.get_gh_username()
     if not gh_user:
         log.error("Could not determine GitHub username")
-        return 0, False
+        return 0, False, "gh credentials expired"
 
     if config.repos:
         repos = set(config.repos)
@@ -303,4 +303,4 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool]:
                     attention = True
 
     log.info("Sync complete: %d changes, attention=%s", changes, attention)
-    return changes, attention
+    return changes, attention, None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import pytest
 from agendum.app import AgendumApp
 from agendum.config import AgendumConfig
@@ -12,3 +14,25 @@ async def test_app_starts_and_quits(tmp_db) -> None:
     async with app.run_test() as pilot:
         assert app.is_running
         await pilot.press("q")
+
+
+def test_sync_status_shows_initial_spinner(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=9999))
+    app._sync_in_progress = True
+
+    assert app._format_sync_status() == "initial sync starting |"
+
+
+def test_sync_status_shows_green_dot_after_success(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=9999))
+    app._last_sync = datetime.now(timezone.utc)
+
+    assert app._format_sync_status() == "🟢 sync status"
+
+
+def test_sync_status_shows_yellow_dot_with_error(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=9999))
+    app._last_sync = datetime.now(timezone.utc)
+    app._sync_error = "gh credentials expired"
+
+    assert app._format_sync_status() == "🟡 sync status (gh credentials expired)"

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -122,7 +122,7 @@ async def test_run_sync_marks_closed_authored_pr_closed(tmp_db: Path, monkeypatc
     monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
-    changes, attention = await run_sync(
+    changes, attention, error = await run_sync(
         tmp_db,
         AgendumConfig(repos=["example-org/example-repo"]),
     )
@@ -130,5 +130,27 @@ async def test_run_sync_marks_closed_authored_pr_closed(tmp_db: Path, monkeypatc
     task = find_task_by_gh_url(tmp_db, url)
     assert changes == 1
     assert attention is False
+    assert error is None
     assert task is not None
     assert task["status"] == "closed"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_reports_missing_gh_auth(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+
+    async def fake_get_gh_username() -> str:
+        return ""
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    assert changes == 0
+    assert attention is False
+    assert error == "gh credentials expired"


### PR DESCRIPTION
## Summary
- show an initial sync startup spinner before the first sync completes
- replace sync age text with green/yellow sync status indicators
- surface missing GitHub credentials as a sync status error

## Tests
- .venv/bin/python -m pytest