### PR TITLE
Fix review detail GraphQL query

### DIFF
--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -151,12 +151,17 @@ query($owner: String!, $name: String!, $user: String!) {
 """
 
 REVIEW_QUERY = """
-query($owner: String!, $name: String!, $number: Int!, $user: String!) {
+query($owner: String!, $name: String!, $number: Int!) {
   repository(owner: $owner, name: $name) {
     pullRequest(number: $number) {
       number title url state createdAt isDraft
       headRefName
-      author { login name }
+      author {
+        login
+        ... on User {
+          name
+        }
+      }
       commits(last: 1) { nodes { commit { committedDate } } }
       reviews(first: 50) {
         nodes { author { login } submittedAt state }
@@ -193,7 +198,6 @@ async def fetch_review_detail(owner: str, name: str, number: int, gh_user: str) 
         "-F", f"owner={owner}",
         "-F", f"name={name}",
         "-F", f"number={number}",
-        "-F", f"user={gh_user}",
     )
     if not result:
         return {}

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -1,8 +1,11 @@
 import json
+import pytest
+
 from agendum.gh import (
     derive_authored_pr_status,
     derive_review_pr_status,
     derive_issue_status,
+    fetch_review_detail,
     parse_author_first_name,
     extract_repo_short_name,
 )
@@ -70,3 +73,39 @@ def test_parse_author_first_name() -> None:
 def test_extract_repo_short_name() -> None:
     assert extract_repo_short_name("example-org/example-repo") == "example-repo"
     assert extract_repo_short_name("org/repo") == "repo"
+
+
+@pytest.mark.asyncio
+async def test_fetch_review_detail_uses_valid_author_name_query(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run_gh(*args: str) -> str:
+        calls.append(args)
+        return json.dumps(
+            {
+                "data": {
+                    "repository": {
+                        "pullRequest": {
+                            "author": {
+                                "login": "reviewer",
+                                "name": "Review Person",
+                            },
+                        },
+                    },
+                },
+            }
+        )
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    result = await fetch_review_detail("example-org", "example-repo", 34, "current-user")
+
+    assert result["data"]["repository"]["pullRequest"]["author"]["name"] == "Review Person"
+    call = calls[0]
+    query_arg = next(arg for arg in call if arg.startswith("query="))
+    assert "$user" not in query_arg
+    assert "-F" in call
+    assert "user=current-user" not in call
+    assert "... on User" in query_arg

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import pytest
 
 from agendum.config import AgendumConfig
-from agendum.db import add_task, find_task_by_gh_url, init_db
+from agendum.db import add_task, find_task_by_gh_url, get_active_tasks, init_db
 from agendum.syncer import diff_tasks, run_sync
 
 
@@ -154,3 +154,80 @@ async def test_run_sync_reports_missing_gh_auth(tmp_db: Path, monkeypatch) -> No
     assert changes == 0
     assert attention is False
     assert error == "gh credentials expired"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_creates_review_requested_pr_with_author_name(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/34"
+
+    async def fake_get_gh_username() -> str:
+        return "reviewer"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return {
+            "data": {
+                "repository": {
+                    "isArchived": False,
+                    "openIssues": {"nodes": []},
+                    "closedIssues": {"nodes": []},
+                    "authoredPRs": {"nodes": []},
+                    "mergedPRs": {"nodes": []},
+                    "closedPRs": {"nodes": []},
+                },
+            },
+        }
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return [
+            {
+                "number": 34,
+                "title": "Fix telemetry attributes",
+                "url": url,
+                "repository": {"nameWithOwner": "example-org/example-repo"},
+                "author": {"login": "author"},
+            }
+        ]
+
+    async def fake_fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
+        return {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": number,
+                        "title": "Fix telemetry attributes",
+                        "url": url,
+                        "author": {"login": "author", "name": "Author Person"},
+                        "commits": {"nodes": [{"commit": {"committedDate": "2026-04-07T20:00:00Z"}}]},
+                        "reviews": {"nodes": []},
+                    },
+                },
+            },
+        }
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_review_detail", fake_fetch_review_detail)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    tasks = get_active_tasks(tmp_db)
+    assert changes == 1
+    assert attention is True
+    assert error is None
+    assert len(tasks) == 1
+    assert tasks[0]["source"] == "pr_review"
+    assert tasks[0]["status"] == "review requested"
+    assert tasks[0]["gh_url"] == url
+    assert tasks[0]["gh_author"] == "author"
+    assert tasks[0]["gh_author_name"] == "Author"


### PR DESCRIPTION
## Summary
- remove the unused review detail GraphQL user variable
- fetch author names through a User inline fragment
- add coverage for review detail query shape and review-requested task creation

## Verification
- uv run pytest
- verified PR #34 detail fetch returns title, URL, and author name