### PR TITLE
Fix IntegrityError when syncing revived terminal tasks

### DIFF
--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -248,19 +248,31 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
                 update_task(db_path, existing_task["id"], status=item["status"])
                 changes += 1
             continue
-        add_task(
-            db_path,
-            title=item["title"],
-            source=item["source"],
-            status=item["status"],
-            project=item.get("project"),
-            gh_repo=item.get("gh_repo"),
-            gh_url=item.get("gh_url"),
-            gh_number=item.get("gh_number"),
-            gh_author=item.get("gh_author"),
-            gh_author_name=item.get("gh_author_name"),
-            tags=item.get("tags"),
-        )
+        existing_task = find_task_by_gh_url(db_path, item["gh_url"]) if item.get("gh_url") else None
+        if existing_task:
+            update_fields = {
+                k: item[k] for k in ("title", "source", "status", "project",
+                                      "gh_repo", "gh_number", "gh_author",
+                                      "gh_author_name", "tags")
+                if item.get(k) is not None
+            }
+            update_fields["seen"] = 0
+            update_fields["last_changed_at"] = now
+            update_task(db_path, existing_task["id"], **update_fields)
+        else:
+            add_task(
+                db_path,
+                title=item["title"],
+                source=item["source"],
+                status=item["status"],
+                project=item.get("project"),
+                gh_repo=item.get("gh_repo"),
+                gh_url=item.get("gh_url"),
+                gh_number=item.get("gh_number"),
+                gh_author=item.get("gh_author"),
+                gh_author_name=item.get("gh_author_name"),
+                tags=item.get("tags"),
+            )
         changes += 1
         if item.get("source") == "pr_review" and item.get("status") == "review requested":
             attention = True

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -136,6 +136,70 @@ async def test_run_sync_marks_closed_authored_pr_closed(tmp_db: Path, monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_run_sync_revives_terminal_task(tmp_db: Path, monkeypatch) -> None:
+    """A previously-closed PR that reappears as open should be updated, not re-inserted."""
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/42"
+    add_task(tmp_db, title="Old PR", source="pr_authored", status="closed", gh_url=url, gh_number=42)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return {
+            "data": {
+                "repository": {
+                    "isArchived": False,
+                    "openIssues": {"nodes": []},
+                    "closedIssues": {"nodes": []},
+                    "authoredPRs": {
+                        "nodes": [
+                            {
+                                "number": 42,
+                                "url": url,
+                                "title": "Reopened PR",
+                                "state": "OPEN",
+                                "isDraft": False,
+                                "reviewDecision": None,
+                                "reviewRequests": {"totalCount": 0},
+                                "labels": {"nodes": []},
+                                "author": {"login": "author"},
+                            }
+                        ],
+                    },
+                    "mergedPRs": {"nodes": []},
+                    "closedPRs": {"nodes": []},
+                },
+            },
+        }
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert error is None
+    assert changes == 1
+    assert task is not None
+    assert task["status"] == "open"
+    assert task["title"] == "Reopened PR"
+
+
+@pytest.mark.asyncio
 async def test_run_sync_reports_missing_gh_auth(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
 


### PR DESCRIPTION
## Summary
- `get_active_tasks` excludes terminal statuses (`merged`/`closed`/`done`), so `diff_tasks` never sees them in the existing set. When a PR that already exists in the DB with a terminal status reappears from GitHub (e.g. reopened), the diff treats it as new and `add_task` hits the UNIQUE constraint on `gh_url`.
- Now checks `find_task_by_gh_url` before inserting in the `to_create` path — if the task already exists, it updates instead of inserting.
- Adds a test for the "revive from terminal" sync scenario.

## Test plan
- [x] All 80 tests pass
- [x] New test `test_run_sync_revives_terminal_task` covers the exact failure scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)