### PR TITLE
feat: suspend GitHub sync during macOS sleep with retry-on-wake

### DIFF
--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -6,6 +6,7 @@ import atexit
 import logging
 import sys
 import textwrap
+import time
 import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
@@ -139,6 +140,10 @@ class AgendumApp(App):
         self._sync_spinner_frame = 0
         self._app_focused = True
         self._modal_task: dict | None = None
+        self._last_sync_mono: float = time.monotonic()
+        self._last_sync_wall: float = time.time()
+        self._suspended = False
+        self._wake_retry_count: int = 0
 
     @property
     def db_path(self) -> Path:
@@ -269,6 +274,8 @@ class AgendumApp(App):
         )
 
     def _format_sync_status(self) -> str:
+        if self._suspended:
+            return "💤 sync suspended (waking up…)"
         if self._sync_error:
             return f"🟡 sync status ({self._sync_error})"
         if self._last_sync:
@@ -364,9 +371,50 @@ class AgendumApp(App):
     # ── sync ─────────────────────────────────────────────────────────
 
     def _start_sync(self) -> None:
-        """Kick off a sync in a background worker."""
+        """Kick off a sync in a background worker.
+
+        Detects system sleep by comparing wall-clock drift against
+        monotonic-clock drift.  On macOS, ``time.monotonic()`` does not
+        advance during system sleep while ``time.time()`` does.  If
+        wall-clock time jumped significantly more than monotonic time,
+        the machine was asleep — enter suspended state and start
+        retry-with-backoff instead of syncing immediately.
+        """
+        now_mono = time.monotonic()
+        now_wall = time.time()
+        mono_elapsed = now_mono - self._last_sync_mono
+        wall_elapsed = now_wall - self._last_sync_wall
+        interval = self._config.sync_interval if self._config else 60
+
+        # Drift = how much more the wall clock advanced than monotonic.
+        # On macOS sleep this equals the sleep duration.
+        drift = wall_elapsed - mono_elapsed
+
+        if drift > interval and self._last_sync is not None:
+            log.info(
+                "Sleep detected (%.0fs wall drift) — starting sync retry",
+                drift,
+            )
+            self._last_sync_mono = now_mono
+            self._last_sync_wall = now_wall
+            self._suspended = True
+            self._wake_retry_count = 0
+            self._update_status_bar()
+            self._retry_sync_after_wake()
+            return
+
+        self._last_sync_mono = now_mono
+        self._last_sync_wall = now_wall
+
         if self._sync_in_progress:
             return
+        self._sync_in_progress = True
+        self._sync_spinner_frame = 0
+        self._update_status_bar()
+        self.run_worker(self._do_sync(), exclusive=True, group="sync")
+
+    def _retry_sync_after_wake(self) -> None:
+        """Attempt a sync as part of the wake retry sequence (Task 2)."""
         self._sync_in_progress = True
         self._sync_spinner_frame = 0
         self._update_status_bar()

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -380,6 +380,9 @@ class AgendumApp(App):
         the machine was asleep — enter suspended state and start
         retry-with-backoff instead of syncing immediately.
         """
+        if self._suspended:
+            return  # wake-retry sequence owns sync scheduling
+
         now_mono = time.monotonic()
         now_wall = time.time()
         mono_elapsed = now_mono - self._last_sync_mono
@@ -415,6 +418,8 @@ class AgendumApp(App):
 
     def _retry_sync_after_wake(self) -> None:
         """Attempt a sync as part of the wake retry sequence."""
+        if self._sync_in_progress:
+            return
         self._sync_in_progress = True
         self._sync_spinner_frame = 0
         self._update_status_bar()

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -418,7 +418,7 @@ class AgendumApp(App):
 
     def _retry_sync_after_wake(self) -> None:
         """Attempt a sync as part of the wake retry sequence."""
-        if self._sync_in_progress:
+        if not self._suspended or self._sync_in_progress:
             return
         self._sync_in_progress = True
         self._sync_spinner_frame = 0

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -414,11 +414,28 @@ class AgendumApp(App):
         self.run_worker(self._do_sync(), exclusive=True, group="sync")
 
     def _retry_sync_after_wake(self) -> None:
-        """Attempt a sync as part of the wake retry sequence (Task 2)."""
+        """Attempt a sync as part of the wake retry sequence."""
         self._sync_in_progress = True
         self._sync_spinner_frame = 0
         self._update_status_bar()
         self.run_worker(self._do_sync(), exclusive=True, group="sync")
+
+    def _handle_wake_retry_failure(self) -> None:
+        """Schedule the next wake-retry attempt with exponential backoff."""
+        self._wake_retry_count += 1
+        delay = min(2 * (2 ** (self._wake_retry_count - 1)), 30)
+        log.info(
+            "Wake retry %d failed — retrying in %ds",
+            self._wake_retry_count, delay,
+        )
+        self._update_status_bar()
+        self.set_timer(delay, self._retry_sync_after_wake)
+
+    def _handle_wake_retry_success(self) -> None:
+        """Clear suspended state after a successful wake-retry sync."""
+        log.info("Wake retry succeeded — resuming normal sync")
+        self._suspended = False
+        self._wake_retry_count = 0
 
     async def _do_sync(self) -> tuple[int, bool, str | None]:
         """Run sync in a worker thread — does not touch UI."""
@@ -433,11 +450,16 @@ class AgendumApp(App):
             if event.state == WorkerState.ERROR:
                 log.exception("Sync failed: %s", event.worker.error)
                 self._sync_error = self._format_sync_error(event.worker.error)
-                self._update_status_bar()
+                if self._suspended:
+                    self._handle_wake_retry_failure()
+                else:
+                    self._update_status_bar()
             return
         changes, attention, error = event.worker.result
         self._last_sync = datetime.now(timezone.utc)
         self._sync_error = error
+        if self._suspended:
+            self._handle_wake_retry_success()
         self.refresh_table()
         self._update_status_bar()
         if attention and not self._app_focused:

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -423,6 +423,11 @@ class AgendumApp(App):
     def _handle_wake_retry_failure(self) -> None:
         """Schedule the next wake-retry attempt with exponential backoff."""
         self._wake_retry_count += 1
+        if self._wake_retry_count > 10:
+            log.warning("Wake retries exhausted — resuming normal sync")
+            self._suspended = False
+            self._wake_retry_count = 0
+            return
         delay = min(2 * (2 ** (self._wake_retry_count - 1)), 30)
         log.info(
             "Wake retry %d failed — retrying in %ds",

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -432,6 +432,7 @@ class AgendumApp(App):
             log.warning("Wake retries exhausted — resuming normal sync")
             self._suspended = False
             self._wake_retry_count = 0
+            self._update_status_bar()
             return
         delay = min(2 * (2 ** (self._wake_retry_count - 1)), 30)
         log.info(
@@ -484,6 +485,10 @@ class AgendumApp(App):
         return message
 
     def action_force_sync(self) -> None:
+        if self._suspended:
+            self._suspended = False
+            self._wake_retry_count = 0
+            log.info("Force sync — clearing suspended state")
         self._start_sync()
 
     # ── focus tracking ───────────────────────────────────────────────

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,4 @@
+import time
 from datetime import datetime, timezone
 
 import pytest
@@ -36,3 +37,85 @@ def test_sync_status_shows_yellow_dot_with_error(tmp_db) -> None:
     app._sync_error = "gh credentials expired"
 
     assert app._format_sync_status() == "🟡 sync status (gh credentials expired)"
+
+
+# ── sleep/wake detection ─────────────────────────────────────────
+
+
+def test_sync_status_shows_suspended_on_sleep(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=9999))
+    app._suspended = True
+
+    assert app._format_sync_status() == "💤 sync suspended (waking up…)"
+
+
+def test_sleep_detected_via_wall_vs_monotonic_drift(tmp_db) -> None:
+    """Simulate macOS sleep: wall clock jumps forward but monotonic does not.
+
+    We fake this by setting _last_sync_wall far in the past while keeping
+    _last_sync_mono close to now, producing a large drift.
+    """
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._last_sync = datetime.now(timezone.utc)  # pretend we've synced before
+
+    now_mono = time.monotonic()
+    now_wall = time.time()
+
+    # Simulate: monotonic barely advanced (60s, one interval) but wall
+    # clock jumped 5 minutes — the system was asleep for ~240s
+    app._last_sync_mono = now_mono - 60
+    app._last_sync_wall = now_wall - 300
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._start_sync()
+
+    assert app._suspended is True
+    assert len(worker_calls) == 1  # retry fires a sync immediately
+
+
+def test_no_sleep_detected_on_normal_interval(tmp_db) -> None:
+    """Normal tick: wall and monotonic advance roughly equally."""
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._last_sync = datetime.now(timezone.utc)
+
+    now_mono = time.monotonic()
+    now_wall = time.time()
+
+    # Both clocks advanced ~60s — no drift
+    app._last_sync_mono = now_mono - 60
+    app._last_sync_wall = now_wall - 60
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._start_sync()
+
+    assert app._suspended is False
+    assert len(worker_calls) == 1
+
+
+def test_first_sync_not_detected_as_sleep(tmp_db) -> None:
+    """The very first sync (last_sync is None) should never be treated
+    as a wake-from-sleep, even if the drift is large."""
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._last_sync = None  # no prior sync
+
+    now_mono = time.monotonic()
+    now_wall = time.time()
+
+    # Huge drift but no prior sync
+    app._last_sync_mono = now_mono - 10
+    app._last_sync_wall = now_wall - 600
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._start_sync()
+
+    assert app._suspended is False
+    assert len(worker_calls) == 1

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -166,7 +166,7 @@ def test_wake_retry_backoff_caps_at_30s(tmp_db) -> None:
     """Backoff delay should cap at 30 seconds."""
     app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
     app._suspended = True
-    app._wake_retry_count = 10  # 2 * 2^10 = 2048, should be capped
+    app._wake_retry_count = 4  # 2 * 2^4 = 32, should be capped to 30
 
     timer_calls: list[tuple] = []
     app.set_timer = lambda delay, cb: timer_calls.append((delay, cb))  # type: ignore[assignment]
@@ -203,3 +203,21 @@ def test_wake_retry_backoff_sequence(tmp_db) -> None:
     for expected in expected_delays:
         app._handle_wake_retry_failure()
         assert timer_calls[-1][0] == expected
+
+
+def test_wake_retry_gives_up_after_max_retries(tmp_db) -> None:
+    """After exceeding max retries, fall back to normal sync."""
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 10  # at the limit
+
+    timer_calls: list[tuple] = []
+    app.set_timer = lambda delay, cb: timer_calls.append((delay, cb))  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._handle_wake_retry_failure()
+
+    # Should give up, not schedule another retry
+    assert app._suspended is False
+    assert app._wake_retry_count == 0
+    assert len(timer_calls) == 0

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,10 @@
 import time
 from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 import pytest
+from textual.worker import Worker, WorkerState
+
 from agendum.app import AgendumApp
 from agendum.config import AgendumConfig
 
@@ -288,3 +291,87 @@ def test_wake_retry_gives_up_after_max_retries(tmp_db) -> None:
     assert app._wake_retry_count == 0
     assert len(timer_calls) == 0
     assert len(status_bar_calls) == 1  # status bar refreshed on exhaustion
+
+
+# ── on_worker_state_changed integration ──────────────────────────
+
+
+def _make_worker_event(state: WorkerState, group: str = "sync", error: BaseException | None = None, result=None):
+    worker = MagicMock(spec=Worker)
+    worker.group = group
+    worker.error = error
+    worker.result = result
+    event = MagicMock(spec=Worker.StateChanged)
+    event.worker = worker
+    event.state = state
+    return event
+
+
+def test_worker_error_while_suspended_triggers_retry(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 2
+    app._sync_in_progress = True
+
+    timer_calls: list[tuple] = []
+    app.set_timer = lambda delay, cb: timer_calls.append((delay, cb))  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    event = _make_worker_event(WorkerState.ERROR, error=RuntimeError("network"))
+    app.on_worker_state_changed(event)
+
+    assert app._sync_in_progress is False
+    assert app._wake_retry_count == 3
+    assert len(timer_calls) == 1  # backoff timer scheduled
+
+
+def test_worker_success_while_suspended_clears_suspended(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 2
+    app._sync_in_progress = True
+    app._app_focused = True
+
+    app.refresh_table = lambda: None  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    event = _make_worker_event(WorkerState.SUCCESS, result=(0, False, None))
+    app.on_worker_state_changed(event)
+
+    assert app._sync_in_progress is False
+    assert app._suspended is False
+    assert app._wake_retry_count == 0
+    assert app._last_sync is not None
+
+
+def test_worker_error_while_not_suspended_does_not_retry(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = False
+    app._sync_in_progress = True
+
+    timer_calls: list[tuple] = []
+    app.set_timer = lambda delay, cb: timer_calls.append((delay, cb))  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    event = _make_worker_event(WorkerState.ERROR, error=RuntimeError("network"))
+    app.on_worker_state_changed(event)
+
+    assert app._sync_in_progress is False
+    assert len(timer_calls) == 0  # no retry scheduled
+
+
+def test_start_sync_skipped_while_sync_in_progress(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._last_sync = datetime.now(timezone.utc)
+    app._sync_in_progress = True
+    app._last_sync_mono = time.monotonic()
+    app._last_sync_wall = time.time()
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._start_sync()
+
+    assert len(worker_calls) == 0
+    assert app._sync_in_progress is True

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -119,3 +119,87 @@ def test_first_sync_not_detected_as_sleep(tmp_db) -> None:
 
     assert app._suspended is False
     assert len(worker_calls) == 1
+
+
+# ── retry-with-backoff after wake ────────────────────────────────
+
+
+def test_wake_retry_attempts_sync_immediately(tmp_db) -> None:
+    """After sleep detection, _retry_sync_after_wake should launch a
+    sync worker immediately (retry 0 = no delay)."""
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 0
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._retry_sync_after_wake()
+
+    assert app._sync_in_progress is True
+    assert len(worker_calls) == 1
+
+
+def test_wake_retry_backs_off_on_failure(tmp_db) -> None:
+    """When a wake-retry sync fails, schedule the next attempt with
+    exponential backoff."""
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 0
+
+    timer_calls: list[tuple] = []
+    app.set_timer = lambda delay, cb: timer_calls.append((delay, cb))  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    # Simulate sync failure during wake retry
+    app._handle_wake_retry_failure()
+
+    assert app._wake_retry_count == 1
+    assert app._suspended is True
+    assert len(timer_calls) == 1
+    # First backoff: 2 * 2^0 = 2s
+    assert timer_calls[0][0] == 2
+
+
+def test_wake_retry_backoff_caps_at_30s(tmp_db) -> None:
+    """Backoff delay should cap at 30 seconds."""
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 10  # 2 * 2^10 = 2048, should be capped
+
+    timer_calls: list[tuple] = []
+    app.set_timer = lambda delay, cb: timer_calls.append((delay, cb))  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._handle_wake_retry_failure()
+
+    assert timer_calls[0][0] == 30
+
+
+def test_wake_retry_success_clears_suspended(tmp_db) -> None:
+    """When a wake-retry sync succeeds, clear suspended state."""
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 3
+
+    app._handle_wake_retry_success()
+
+    assert app._suspended is False
+    assert app._wake_retry_count == 0
+
+
+def test_wake_retry_backoff_sequence(tmp_db) -> None:
+    """Verify the full backoff sequence: 2, 4, 8, 16, 30, 30."""
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 0
+
+    timer_calls: list[tuple] = []
+    app.set_timer = lambda delay, cb: timer_calls.append((delay, cb))  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    expected_delays = [2, 4, 8, 16, 30, 30]
+    for expected in expected_delays:
+        app._handle_wake_retry_failure()
+        assert timer_calls[-1][0] == expected

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -205,6 +205,35 @@ def test_wake_retry_backoff_sequence(tmp_db) -> None:
         assert timer_calls[-1][0] == expected
 
 
+def test_start_sync_skipped_while_suspended(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._last_sync = datetime.now(timezone.utc)
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._start_sync()
+
+    assert len(worker_calls) == 0
+
+
+def test_retry_sync_skipped_while_sync_in_progress(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._sync_in_progress = True
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app._retry_sync_after_wake()
+
+    assert len(worker_calls) == 0
+    assert app._sync_in_progress is True  # unchanged
+
+
 def test_wake_retry_gives_up_after_max_retries(tmp_db) -> None:
     """After exceeding max retries, fall back to normal sync."""
     app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -234,6 +234,25 @@ def test_retry_sync_skipped_while_sync_in_progress(tmp_db) -> None:
     assert app._sync_in_progress is True  # unchanged
 
 
+def test_force_sync_clears_suspended_state(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = True
+    app._wake_retry_count = 5
+    app._last_sync = datetime.now(timezone.utc)
+    app._last_sync_mono = time.monotonic()
+    app._last_sync_wall = time.time()
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    app.action_force_sync()
+
+    assert app._suspended is False
+    assert app._wake_retry_count == 0
+    assert len(worker_calls) == 1
+
+
 def test_wake_retry_gives_up_after_max_retries(tmp_db) -> None:
     """After exceeding max retries, fall back to normal sync."""
     app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
@@ -244,9 +263,13 @@ def test_wake_retry_gives_up_after_max_retries(tmp_db) -> None:
     app.set_timer = lambda delay, cb: timer_calls.append((delay, cb))  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
+    status_bar_calls: list = []
+    app._update_status_bar = lambda: status_bar_calls.append(1)  # type: ignore[assignment]
+
     app._handle_wake_retry_failure()
 
     # Should give up, not schedule another retry
     assert app._suspended is False
     assert app._wake_retry_count == 0
     assert len(timer_calls) == 0
+    assert len(status_bar_calls) == 1  # status bar refreshed on exhaustion

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -253,6 +253,21 @@ def test_force_sync_clears_suspended_state(tmp_db) -> None:
     assert len(worker_calls) == 1
 
 
+def test_stale_retry_timer_is_noop_after_force_sync(tmp_db) -> None:
+    app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))
+    app._suspended = False  # force sync already cleared this
+    app._wake_retry_count = 0
+
+    worker_calls: list = []
+    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+
+    # Simulate an orphaned backoff timer firing after suspended was cleared
+    app._retry_sync_after_wake()
+
+    assert len(worker_calls) == 0
+
+
 def test_wake_retry_gives_up_after_max_retries(tmp_db) -> None:
     """After exceeding max retries, fall back to normal sync."""
     app = AgendumApp(db_path=tmp_db, config=AgendumConfig(orgs=[], sync_interval=60))


### PR DESCRIPTION
## Summary

- Detect macOS system sleep by comparing wall clock (`time.time()`) against monotonic clock (`time.monotonic()`) — on macOS, monotonic doesn't advance during sleep, so the divergence reveals sleep duration
- On wake, attempt sync immediately; if it fails (network not ready), retry with exponential backoff (2s, 4s, 8s, 16s, cap 30s)
- Give up after 10 retries (~3 min) and fall back to normal sync cadence
- Status bar shows `💤 sync suspended (waking up…)` during retry sequence

### Why not just `time.monotonic()` gap detection?

`time.monotonic()` uses `mach_absolute_time()` on macOS, which Apple documents as not incrementing during system sleep. A monotonic-only gap check would never trigger for the exact scenario we're solving.

## Test plan

- [x] `test_sleep_detected_via_wall_vs_monotonic_drift` — simulates wall clock jump with stable monotonic
- [x] `test_no_sleep_detected_on_normal_interval` — both clocks advance equally, no false positive
- [x] `test_first_sync_not_detected_as_sleep` — initial sync never treated as wake
- [x] `test_wake_retry_attempts_sync_immediately` — first retry has zero delay
- [x] `test_wake_retry_backs_off_on_failure` — first backoff is 2s
- [x] `test_wake_retry_backoff_caps_at_30s` — delay never exceeds 30s
- [x] `test_wake_retry_backoff_sequence` — verifies full sequence 2, 4, 8, 16, 30, 30
- [x] `test_wake_retry_gives_up_after_max_retries` — falls back to normal sync after 10 retries
- [x] `test_wake_retry_success_clears_suspended` — clears suspended state on success
- [x] Full suite: 153/153 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)