### PR TITLE
Add review received authored PR status

### DIFF
--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -7,6 +7,7 @@ import json
 import logging
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 log = logging.getLogger(__name__)
 
@@ -21,6 +22,11 @@ def derive_authored_pr_status(
     review_decision: str | None,
     state: str,
     has_review_requests: bool = False,
+    latest_commit_time: str | None = None,
+    latest_comment_review_id: str | None = None,
+    latest_comment_review_time: str | None = None,
+    author_login: str | None = None,
+    review_threads: list[dict[str, Any]] | None = None,
 ) -> str:
     if state == "MERGED":
         return "merged"
@@ -32,6 +38,14 @@ def derive_authored_pr_status(
         return "approved"
     if review_decision == "CHANGES_REQUESTED":
         return "changes requested"
+    if has_unacknowledged_review_feedback(
+        latest_comment_review_id=latest_comment_review_id,
+        latest_comment_review_time=latest_comment_review_time,
+        latest_commit_time=latest_commit_time,
+        author_login=author_login,
+        review_threads=review_threads or [],
+    ):
+        return "review received"
     if has_review_requests:
         return "awaiting review"
     return "open"
@@ -65,6 +79,85 @@ def parse_author_first_name(display_name: str | None) -> str | None:
 
 def extract_repo_short_name(full_repo: str) -> str:
     return full_repo.split("/", 1)[-1]
+
+
+def _parse_github_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def _thread_has_author_reply_after(
+    thread: dict[str, Any],
+    *,
+    author_login: str,
+    review_time: str,
+) -> bool:
+    comments = (thread.get("comments") or {}).get("nodes", [])
+    for comment in comments:
+        comment_author = (comment.get("author") or {}).get("login", "")
+        created_at = comment.get("createdAt")
+        if (
+            comment_author.lower() == author_login.lower()
+            and created_at
+            and created_at > review_time
+        ):
+            return True
+    return False
+
+
+def _relevant_review_threads(
+    review_threads: list[dict[str, Any]],
+    *,
+    review_id: str,
+) -> list[dict[str, Any]]:
+    relevant: list[dict[str, Any]] = []
+    for thread in review_threads:
+        comments = (thread.get("comments") or {}).get("nodes", [])
+        if any(
+            ((comment.get("pullRequestReview") or {}).get("id") == review_id)
+            for comment in comments
+        ):
+            relevant.append(thread)
+    return relevant
+
+
+def has_unacknowledged_review_feedback(
+    *,
+    latest_comment_review_id: str | None,
+    latest_comment_review_time: str | None,
+    latest_commit_time: str | None,
+    author_login: str | None,
+    review_threads: list[dict[str, Any]],
+) -> bool:
+    if not latest_comment_review_id or not latest_comment_review_time:
+        return False
+
+    relevant_threads = _relevant_review_threads(
+        review_threads,
+        review_id=latest_comment_review_id,
+    )
+    if author_login:
+        for thread in relevant_threads:
+            if _thread_has_author_reply_after(
+                thread,
+                author_login=author_login,
+                review_time=latest_comment_review_time,
+            ):
+                return False
+    if relevant_threads and all(thread.get("isResolved", False) for thread in relevant_threads):
+        return False
+
+    review_dt = _parse_github_datetime(latest_comment_review_time)
+    commit_dt = _parse_github_datetime(latest_commit_time)
+    if not relevant_threads and review_dt and commit_dt and commit_dt > review_dt:
+        return False
+
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -131,6 +224,34 @@ query($owner: String!, $name: String!, $user: String!) {
         author { login }
         reviewDecision
         reviewRequests(first: 10) { totalCount }
+        commits(last: 1) {
+          nodes {
+            commit {
+              committedDate
+            }
+          }
+        }
+        reviews(last: 20) {
+          nodes {
+            id
+            state
+            submittedAt
+            author { login }
+          }
+        }
+        reviewThreads(last: 50) {
+          nodes {
+            isResolved
+            isOutdated
+            comments(last: 20) {
+              nodes {
+                createdAt
+                pullRequestReview { id }
+                author { login }
+              }
+            }
+          }
+        }
         labels(first: 10) { nodes { name } }
       }
     }

--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -25,6 +25,7 @@ def derive_authored_pr_status(
     latest_commit_time: str | None = None,
     latest_comment_review_id: str | None = None,
     latest_comment_review_time: str | None = None,
+    qualifying_reviews: list[dict[str, Any]] | None = None,
     author_login: str | None = None,
     review_threads: list[dict[str, Any]] | None = None,
 ) -> str:
@@ -43,6 +44,7 @@ def derive_authored_pr_status(
         latest_comment_review_time=latest_comment_review_time,
         latest_commit_time=latest_commit_time,
         author_login=author_login,
+        qualifying_reviews=qualifying_reviews or [],
         review_threads=review_threads or [],
     ):
         return "review received"
@@ -132,32 +134,50 @@ def has_unacknowledged_review_feedback(
     latest_comment_review_time: str | None,
     latest_commit_time: str | None,
     author_login: str | None,
+    qualifying_reviews: list[dict[str, Any]],
     review_threads: list[dict[str, Any]],
 ) -> bool:
-    if not latest_comment_review_id or not latest_comment_review_time:
+    reviews = qualifying_reviews
+    if not reviews and latest_comment_review_id and latest_comment_review_time:
+        reviews = [
+            {
+                "id": latest_comment_review_id,
+                "submittedAt": latest_comment_review_time,
+            },
+        ]
+    if not reviews:
         return False
 
-    relevant_threads = _relevant_review_threads(
-        review_threads,
-        review_id=latest_comment_review_id,
-    )
-    if author_login:
-        for thread in relevant_threads:
-            if _thread_has_author_reply_after(
-                thread,
-                author_login=author_login,
-                review_time=latest_comment_review_time,
-            ):
-                return False
-    if relevant_threads and all(thread.get("isResolved", False) for thread in relevant_threads):
-        return False
-
-    review_dt = _parse_github_datetime(latest_comment_review_time)
     commit_dt = _parse_github_datetime(latest_commit_time)
-    if not relevant_threads and review_dt and commit_dt and commit_dt > review_dt:
-        return False
 
-    return True
+    for review in reviews:
+        review_id = review.get("id")
+        review_time = review.get("submittedAt")
+        if not review_id or not review_time:
+            continue
+
+        relevant_threads = _relevant_review_threads(
+            review_threads,
+            review_id=review_id,
+        )
+        if relevant_threads:
+            for thread in relevant_threads:
+                if thread.get("isResolved", False):
+                    continue
+                if author_login and _thread_has_author_reply_after(
+                    thread,
+                    author_login=author_login,
+                    review_time=review_time,
+                ):
+                    continue
+                return True
+            continue
+
+        review_dt = _parse_github_datetime(review_time)
+        if not review_dt or not commit_dt or commit_dt <= review_dt:
+            return True
+
+    return False
 
 
 # ---------------------------------------------------------------------------

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -109,11 +109,37 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
                 author_login = (pr.get("author") or {}).get("login", "")
                 if author_login.lower() != gh_user.lower():
                     continue
+                reviews = pr.get("reviews", {}).get("nodes", [])
+                qualifying_reviews = [
+                    review
+                    for review in reviews
+                    if (review.get("author") or {}).get("login", "").lower() != gh_user.lower()
+                    and review.get("submittedAt")
+                    and review.get("id")
+                    and review.get("state") not in ("APPROVED", "CHANGES_REQUESTED", "PENDING")
+                ]
+                latest_comment_review = None
+                if qualifying_reviews:
+                    latest_comment_review = max(
+                        qualifying_reviews,
+                        key=lambda review: review.get("submittedAt", ""),
+                    )
+                last_commit_nodes = pr.get("commits", {}).get("nodes", [])
+                latest_commit_time = None
+                if last_commit_nodes:
+                    latest_commit_time = (
+                        last_commit_nodes[0].get("commit", {}).get("committedDate")
+                    )
                 status = gh.derive_authored_pr_status(
                     is_draft=pr.get("isDraft", False),
                     review_decision=pr.get("reviewDecision"),
                     state=pr.get("state", "OPEN"),
                     has_review_requests=(pr.get("reviewRequests", {}).get("totalCount", 0) > 0),
+                    latest_commit_time=latest_commit_time,
+                    latest_comment_review_id=(latest_comment_review or {}).get("id"),
+                    latest_comment_review_time=(latest_comment_review or {}).get("submittedAt"),
+                    author_login=author_login,
+                    review_threads=pr.get("reviewThreads", {}).get("nodes", []),
                 )
                 labels = [l["name"] for l in (pr.get("labels", {}).get("nodes", []))]
                 incoming_tasks.append({
@@ -283,7 +309,7 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
         item["last_changed_at"] = now
         update_task(db_path, task_id, **item)
         changes += 1
-        if "status" in item and item["status"] in ("changes requested", "approved"):
+        if "status" in item and item["status"] in ("changes requested", "approved", "review received"):
             attention = True
 
     for item in diff.to_close:

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -138,6 +138,7 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
                     latest_commit_time=latest_commit_time,
                     latest_comment_review_id=(latest_comment_review or {}).get("id"),
                     latest_comment_review_time=(latest_comment_review or {}).get("submittedAt"),
+                    qualifying_reviews=qualifying_reviews,
                     author_login=author_login,
                     review_threads=pr.get("reviewThreads", {}).get("nodes", []),
                 )

--- a/src/agendum/widgets.py
+++ b/src/agendum/widgets.py
@@ -16,6 +16,7 @@ STATUS_STYLES: dict[str, str] = {
     "open": "#60a5fa",
     "awaiting review": "#ffaa00",
     "changes requested": "#f87171",
+    "review received": "#f59e0b",
     "approved": "#4ade80",
     "merged": "#888888",
     "review requested": "#a78bfa",

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -11,6 +11,22 @@ from agendum.gh import (
 )
 
 
+def authored_pr_status_with_review_feedback(**overrides: object) -> str:
+    kwargs = {
+        "is_draft": False,
+        "review_decision": None,
+        "state": "OPEN",
+        "has_review_requests": False,
+        "latest_commit_time": None,
+        "latest_comment_review_id": None,
+        "latest_comment_review_time": None,
+        "author_login": "author",
+        "review_threads": [],
+    }
+    kwargs.update(overrides)
+    return derive_authored_pr_status(**kwargs)
+
+
 def test_authored_pr_draft() -> None:
     assert derive_authored_pr_status(is_draft=True, review_decision=None, state="OPEN") == "draft"
 
@@ -23,8 +39,26 @@ def test_authored_pr_awaiting_review() -> None:
     assert derive_authored_pr_status(is_draft=False, review_decision=None, state="OPEN", has_review_requests=True) == "awaiting review"
 
 
-def test_authored_pr_changes_requested() -> None:
-    assert derive_authored_pr_status(is_draft=False, review_decision="CHANGES_REQUESTED", state="OPEN") == "changes requested"
+def test_authored_pr_changes_requested_overrides_review_received() -> None:
+    assert authored_pr_status_with_review_feedback(
+        review_decision="CHANGES_REQUESTED",
+        latest_comment_review_id="review-1",
+        latest_comment_review_time="2026-04-10T12:00:00Z",
+        review_threads=[
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T12:01:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-1"},
+                        },
+                    ],
+                },
+            },
+        ],
+    ) == "changes requested"
 
 
 def test_authored_pr_approved() -> None:
@@ -37,6 +71,104 @@ def test_authored_pr_merged() -> None:
 
 def test_authored_pr_closed() -> None:
     assert derive_authored_pr_status(is_draft=False, review_decision=None, state="CLOSED") == "closed"
+
+
+def test_authored_pr_review_received_for_non_blocking_feedback() -> None:
+    assert authored_pr_status_with_review_feedback(
+        latest_comment_review_id="review-1",
+        latest_comment_review_time="2026-04-10T12:00:00Z",
+        review_threads=[
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T12:01:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-1"},
+                        },
+                    ],
+                },
+            },
+        ],
+    ) == "review received"
+
+
+def test_authored_pr_review_received_clears_after_author_reply() -> None:
+    assert authored_pr_status_with_review_feedback(
+        latest_comment_review_id="review-1",
+        latest_comment_review_time="2026-04-10T12:00:00Z",
+        review_threads=[
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T12:01:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-1"},
+                        },
+                        {
+                            "createdAt": "2026-04-10T12:05:00Z",
+                            "author": {"login": "author"},
+                            "pullRequestReview": {"id": None},
+                        },
+                    ],
+                },
+            },
+        ],
+    ) == "open"
+
+
+def test_authored_pr_review_received_clears_after_threads_resolved() -> None:
+    assert authored_pr_status_with_review_feedback(
+        latest_comment_review_id="review-1",
+        latest_comment_review_time="2026-04-10T12:00:00Z",
+        review_threads=[
+            {
+                "isResolved": True,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T12:01:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-1"},
+                        },
+                    ],
+                },
+            },
+        ],
+    ) == "open"
+
+
+def test_authored_pr_review_received_persists_after_push_when_feedback_threads_exist() -> None:
+    assert authored_pr_status_with_review_feedback(
+        latest_comment_review_id="review-1",
+        latest_comment_review_time="2026-04-10T12:00:00Z",
+        latest_commit_time="2026-04-10T12:05:00Z",
+        review_threads=[
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T12:01:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-1"},
+                        },
+                    ],
+                },
+            },
+        ],
+    ) == "review received"
+
+
+def test_authored_pr_review_received_clears_after_push_without_feedback_threads() -> None:
+    assert authored_pr_status_with_review_feedback(
+        latest_comment_review_id="review-1",
+        latest_comment_review_time="2026-04-10T12:00:00Z",
+        latest_commit_time="2026-04-10T12:05:00Z",
+    ) == "open"
 
 
 def test_review_pr_requested() -> None:

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -94,6 +94,89 @@ def test_authored_pr_review_received_for_non_blocking_feedback() -> None:
     ) == "review received"
 
 
+def test_authored_pr_review_received_stays_active_with_sibling_thread_reply() -> None:
+    assert authored_pr_status_with_review_feedback(
+        qualifying_reviews=[
+            {
+                "id": "review-1",
+                "submittedAt": "2026-04-10T12:00:00Z",
+            },
+        ],
+        review_threads=[
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T12:01:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-1"},
+                        },
+                        {
+                            "createdAt": "2026-04-10T12:02:00Z",
+                            "author": {"login": "author"},
+                            "pullRequestReview": {"id": None},
+                        },
+                    ],
+                },
+            },
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T12:03:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-1"},
+                        },
+                    ],
+                },
+            },
+        ],
+    ) == "review received"
+
+
+def test_authored_pr_review_received_stays_active_for_older_unresolved_review() -> None:
+    assert authored_pr_status_with_review_feedback(
+        qualifying_reviews=[
+            {
+                "id": "review-old",
+                "submittedAt": "2026-04-10T11:00:00Z",
+            },
+            {
+                "id": "review-new",
+                "submittedAt": "2026-04-10T12:00:00Z",
+            },
+        ],
+        review_threads=[
+            {
+                "isResolved": False,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T11:01:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-old"},
+                        },
+                    ],
+                },
+            },
+            {
+                "isResolved": True,
+                "comments": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-10T12:01:00Z",
+                            "author": {"login": "reviewer"},
+                            "pullRequestReview": {"id": "review-new"},
+                        },
+                    ],
+                },
+            },
+        ],
+    ) == "review received"
+
+
 def test_authored_pr_review_received_clears_after_author_reply() -> None:
     assert authored_pr_status_with_review_feedback(
         latest_comment_review_id="review-1",

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -7,6 +7,83 @@ from agendum.db import add_task, find_task_by_gh_url, get_active_tasks, init_db
 from agendum.syncer import diff_tasks, run_sync
 
 
+def make_review(
+    *,
+    author: str,
+    submitted_at: str,
+    state: str,
+    review_id: str = "review-1",
+    body: str = "feedback",
+) -> dict:
+    return {
+        "id": review_id,
+        "author": {"login": author},
+        "submittedAt": submitted_at,
+        "state": state,
+        "body": body,
+    }
+
+
+def make_thread(*, is_resolved: bool, comments: list[dict]) -> dict:
+    return {
+        "isResolved": is_resolved,
+        "comments": {"nodes": comments},
+    }
+
+
+def make_thread_comment(
+    *,
+    author: str,
+    created_at: str,
+    review_id: str | None = None,
+) -> dict:
+    return {
+        "author": {"login": author},
+        "createdAt": created_at,
+        "pullRequestReview": {"id": review_id} if review_id is not None else None,
+    }
+
+
+def make_authored_pr(
+    *,
+    gh_user: str,
+    url: str,
+    review_decision: str | None = None,
+    last_commit_at: str = "2026-04-07T20:00:00Z",
+    reviews: list[dict] | None = None,
+    review_threads: list[dict] | None = None,
+) -> dict:
+    return {
+        "number": 12,
+        "title": "Improve sync status handling",
+        "url": url,
+        "state": "OPEN",
+        "isDraft": False,
+        "author": {"login": gh_user},
+        "reviewDecision": review_decision,
+        "reviewRequests": {"totalCount": 0},
+        "labels": {"nodes": []},
+        "commits": {"nodes": [{"commit": {"committedDate": last_commit_at}}]},
+        "reviews": {"nodes": reviews or []},
+        "reviewThreads": {"nodes": review_threads or []},
+    }
+
+
+def authored_repo_payload(*, authored_prs: list[dict]) -> dict:
+    return {
+        "data": {
+            "repository": {
+                "isArchived": False,
+                "openIssues": {"nodes": []},
+                "closedIssues": {"nodes": []},
+                "authoredPRs": {"nodes": authored_prs},
+                "mergedPRs": {"nodes": []},
+                "closedPRs": {"nodes": []},
+            },
+        },
+    }
+
+
 def test_diff_detects_new_task() -> None:
     existing: list[dict] = []
     incoming = [
@@ -295,3 +372,375 @@ async def test_run_sync_creates_review_requested_pr_with_author_name(tmp_db: Pat
     assert tasks[0]["gh_url"] == url
     assert tasks[0]["gh_author"] == "author"
     assert tasks[0]["gh_author_name"] == "Author"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_sets_authored_pr_to_review_received_for_non_blocking_feedback(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/12"
+    add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="open", gh_url=url)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return authored_repo_payload(
+            authored_prs=[
+                make_authored_pr(
+                    gh_user=gh_user,
+                    url=url,
+                    reviews=[
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T12:00:00Z",
+                            state="COMMENTED",
+                        ),
+                    ],
+                    review_threads=[
+                        make_thread(
+                            is_resolved=False,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T12:01:00Z",
+                                    review_id="review-1",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert changes == 1
+    assert error is None
+    assert task is not None
+    assert task["status"] == "review received"
+    assert task["seen"] == 0
+
+
+@pytest.mark.asyncio
+async def test_run_sync_keeps_changes_requested_for_blocking_review(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/12"
+    add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="open", gh_url=url)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return authored_repo_payload(
+            authored_prs=[
+                make_authored_pr(
+                    gh_user=gh_user,
+                    url=url,
+                    review_decision="CHANGES_REQUESTED",
+                    reviews=[
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T12:00:00Z",
+                            state="CHANGES_REQUESTED",
+                        ),
+                    ],
+                    review_threads=[
+                        make_thread(
+                            is_resolved=False,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T12:01:00Z",
+                                    review_id="review-1",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert changes == 1
+    assert error is None
+    assert task is not None
+    assert task["status"] == "changes requested"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_clears_review_received_after_author_reply(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/12"
+    add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return authored_repo_payload(
+            authored_prs=[
+                make_authored_pr(
+                    gh_user=gh_user,
+                    url=url,
+                    reviews=[
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T12:00:00Z",
+                            state="COMMENTED",
+                        ),
+                    ],
+                    review_threads=[
+                        make_thread(
+                            is_resolved=False,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T12:01:00Z",
+                                    review_id="review-1",
+                                ),
+                                make_thread_comment(author="author", created_at="2026-04-10T12:05:00Z"),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert changes == 1
+    assert error is None
+    assert task is not None
+    assert task["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_clears_review_received_after_all_threads_resolved(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/12"
+    add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return authored_repo_payload(
+            authored_prs=[
+                make_authored_pr(
+                    gh_user=gh_user,
+                    url=url,
+                    reviews=[
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T12:00:00Z",
+                            state="COMMENTED",
+                        ),
+                    ],
+                    review_threads=[
+                        make_thread(
+                            is_resolved=True,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T12:01:00Z",
+                                    review_id="review-1",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert changes == 1
+    assert error is None
+    assert task is not None
+    assert task["status"] == "open"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_keeps_review_received_after_push_when_feedback_threads_exist(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/12"
+    add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return authored_repo_payload(
+            authored_prs=[
+                make_authored_pr(
+                    gh_user=gh_user,
+                    url=url,
+                    last_commit_at="2026-04-10T12:05:00Z",
+                    reviews=[
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T12:00:00Z",
+                            state="COMMENTED",
+                        ),
+                    ],
+                    review_threads=[
+                        make_thread(
+                            is_resolved=False,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T12:01:00Z",
+                                    review_id="review-1",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert changes == 1
+    assert error is None
+    assert task is not None
+    assert task["status"] == "review received"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_clears_review_received_after_push_without_feedback_threads(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/12"
+    add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return authored_repo_payload(
+            authored_prs=[
+                make_authored_pr(
+                    gh_user=gh_user,
+                    url=url,
+                    last_commit_at="2026-04-10T12:05:00Z",
+                    reviews=[
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T12:00:00Z",
+                            state="COMMENTED",
+                        ),
+                    ],
+                    review_threads=[],
+                ),
+            ],
+        )
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert changes == 1
+    assert error is None
+    assert task is not None
+    assert task["status"] == "open"

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -567,6 +567,162 @@ async def test_run_sync_clears_review_received_after_author_reply(tmp_db: Path, 
 
 
 @pytest.mark.asyncio
+async def test_run_sync_keeps_review_received_with_sibling_thread_reply(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/12"
+    add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return authored_repo_payload(
+            authored_prs=[
+                make_authored_pr(
+                    gh_user=gh_user,
+                    url=url,
+                    reviews=[
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T12:00:00Z",
+                            state="COMMENTED",
+                        ),
+                    ],
+                    review_threads=[
+                        make_thread(
+                            is_resolved=False,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T12:01:00Z",
+                                    review_id="review-1",
+                                ),
+                                make_thread_comment(author="author", created_at="2026-04-10T12:05:00Z"),
+                            ],
+                        ),
+                        make_thread(
+                            is_resolved=False,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T12:02:00Z",
+                                    review_id="review-1",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert changes == 1
+    assert attention is False
+    assert error is None
+    assert task is not None
+    assert task["status"] == "review received"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_keeps_review_received_when_older_review_is_unresolved(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/12"
+    add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return authored_repo_payload(
+            authored_prs=[
+                make_authored_pr(
+                    gh_user=gh_user,
+                    url=url,
+                    reviews=[
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T11:00:00Z",
+                            state="COMMENTED",
+                            review_id="review-old",
+                        ),
+                        make_review(
+                            author="reviewer",
+                            submitted_at="2026-04-10T12:00:00Z",
+                            state="COMMENTED",
+                            review_id="review-new",
+                        ),
+                    ],
+                    review_threads=[
+                        make_thread(
+                            is_resolved=False,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T11:01:00Z",
+                                    review_id="review-old",
+                                ),
+                            ],
+                        ),
+                        make_thread(
+                            is_resolved=True,
+                            comments=[
+                                make_thread_comment(
+                                    author="reviewer",
+                                    created_at="2026-04-10T12:01:00Z",
+                                    review_id="review-new",
+                                ),
+                            ],
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+        return []
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert changes == 1
+    assert attention is False
+    assert error is None
+    assert task is not None
+    assert task["status"] == "review received"
+
+
+@pytest.mark.asyncio
 async def test_run_sync_clears_review_received_after_all_threads_resolved(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
     url = "https://github.com/example-org/example-repo/pull/12"


### PR DESCRIPTION
## Summary
- add a new authored PR status, review received, for non-approving reviews with actionable feedback
- keep changes requested higher precedence and only clear review received on push when the triggering review has no linked review-thread feedback
- surface the new status in the TUI and expand pure/status sync coverage for replies, resolutions, and push behavior

## Testing
- uv run pytest