### PR TITLE
chore: sync v0.1.1 release metadata back to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+## v0.1.1 (2026-04-16)
+
+### Feat
+
+- add release discipline and packaging scaffolding
+- add max retry limit for wake sync retries
+- implement retry-with-backoff after wake from sleep
+- replace monotonic-only sleep detection with wall-vs-monotonic drift
+- **ui**: wrap title column instead of truncating
+- **ui**: right-align link column in task table
+- agendum — terminal dashboard for GitHub tasks
+
+### Fix
+
+- discard stale backoff timers after suspended state is cleared
+- force-sync overrides suspended state, refresh status on retry exhaustion
+- prevent periodic sync timer from forking wake-retry chain
+- **sync**: handle null timestamps in review comparison
+- **ui**: increase selected row contrast
+- **ui**: restore cursor position after table refresh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agendum"
-version = "0.1.0"
+version = "0.1.1"
 description = "Terminal dashboard for GitHub PRs, issues, and tasks"
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/src/agendum/__init__.py
+++ b/src/agendum/__init__.py
@@ -1,3 +1,3 @@
 """Agendum — terminal dashboard for GitHub tasks."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
## Summary
- bring the already-published v0.1.1 release commit back onto main
- add CHANGELOG.md
- update package version metadata to 0.1.1

## Context
The first release workflow successfully created and pushed tag , but branch protection blocked the workflow from pushing the corresponding release commit to .

## Validation
- release tag exists: v0.1.1
- GitHub release exists: https://github.com/danseely/agendum/releases/tag/v0.1.1