### PR TITLE
fix: GitHub items disappearing on API failure

### DIFF
--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -404,9 +404,14 @@ async def discover_repos(orgs: list[str], gh_user: str) -> set[str]:
     return repos
 
 
-async def discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-    """Find all PRs where user's review is requested, across all orgs."""
+async def discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+    """Find all PRs where user's review is requested, across all orgs.
+
+    Returns (prs, ok) where *ok* is False if any org query failed,
+    indicating the result set may be incomplete.
+    """
     prs: list[dict] = []
+    ok = True
     for org in orgs:
         out = await _run_gh(
             "search", "prs",
@@ -418,7 +423,9 @@ async def discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
         )
         if out:
             prs.extend(json.loads(out))
-    return prs
+        else:
+            ok = False
+    return prs, ok
 
 
 async def fetch_notifications(gh_user: str) -> list[dict]:

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -29,8 +29,22 @@ class SyncResult:
     to_close: list[dict] = field(default_factory=list)
 
 
-def diff_tasks(existing: list[dict], incoming: list[dict]) -> SyncResult:
-    """Compare existing DB tasks against incoming GitHub state."""
+def diff_tasks(
+    existing: list[dict],
+    incoming: list[dict],
+    *,
+    fetched_repos: set[str] | None = None,
+    review_fetch_ok: bool = True,
+) -> SyncResult:
+    """Compare existing DB tasks against incoming GitHub state.
+
+    If *fetched_repos* is provided, only close tasks whose repo was
+    actually fetched.  This prevents a partial API failure from
+    wiping out items belonging to repos that simply weren't reached.
+
+    If *review_fetch_ok* is False, review tasks are never closed
+    (the review discovery may have returned incomplete results).
+    """
     result = SyncResult()
 
     existing_by_url: dict[str, dict] = {}
@@ -66,6 +80,14 @@ def diff_tasks(existing: list[dict], incoming: list[dict]) -> SyncResult:
     for task in existing:
         url = task.get("gh_url")
         if url and url not in incoming_urls and task.get("source") != "manual":
+            # Don't close review tasks when the review fetch was incomplete.
+            if not review_fetch_ok and task.get("source") == "pr_review":
+                continue
+            # Only close items from repos we actually fetched data for.
+            if fetched_repos is not None:
+                task_repo = task.get("gh_repo", "")
+                if task_repo not in fetched_repos:
+                    continue
             result.to_close.append(task)
 
     return result
@@ -93,6 +115,7 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
 
     sem = asyncio.Semaphore(8)
     incoming_tasks: list[dict] = []
+    fetched_repos: set[str] = set()  # repos we got data from
 
     async def fetch_one_repo(repo_full: str) -> None:
         async with sem:
@@ -103,6 +126,7 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
             repo_data = data.get("data", {}).get("repository", {})
             if not repo_data or repo_data.get("isArchived"):
                 return
+            fetched_repos.add(repo_full)
             short_name = gh.extract_repo_short_name(repo_full)
 
             for pr in repo_data.get("authoredPRs", {}).get("nodes", []):
@@ -213,7 +237,7 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
 
     await asyncio.gather(*(fetch_one_repo(r) for r in repos))
 
-    review_prs = await gh.discover_review_prs(config.orgs, gh_user)
+    review_prs, review_fetch_ok = await gh.discover_review_prs(config.orgs, gh_user)
     for pr_info in review_prs:
         repo_info = pr_info.get("repository", {})
         repo_full = repo_info.get("nameWithOwner", "")
@@ -261,8 +285,17 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
             "tags": json.dumps(["review"]),
         })
 
+    # If review discovery failed, don't let the diff close review tasks
+    # from repos we didn't get review data for.
+    if not review_fetch_ok:
+        log.warning("Review PR discovery had failures — skipping review task cleanup")
+
     existing = get_active_tasks(db_path)
-    diff = diff_tasks(existing, incoming_tasks)
+    diff = diff_tasks(
+        existing, incoming_tasks,
+        fetched_repos=fetched_repos,
+        review_fetch_ok=review_fetch_ok,
+    )
 
     changes = 0
     attention = False

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -186,8 +186,8 @@ async def test_run_sync_marks_closed_authored_pr_closed(tmp_db: Path, monkeypatc
             },
         }
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -250,8 +250,8 @@ async def test_run_sync_revives_terminal_task(tmp_db: Path, monkeypatch) -> None
             },
         }
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -319,7 +319,7 @@ async def test_run_sync_creates_review_requested_pr_with_author_name(tmp_db: Pat
             },
         }
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
         return [
             {
                 "number": 34,
@@ -328,7 +328,7 @@ async def test_run_sync_creates_review_requested_pr_with_author_name(tmp_db: Pat
                 "repository": {"nameWithOwner": "example-org/example-repo"},
                 "author": {"login": "author"},
             }
-        ]
+        ], True
 
     async def fake_fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
         return {
@@ -412,8 +412,8 @@ async def test_run_sync_sets_authored_pr_to_review_received_for_non_blocking_fee
             ],
         )
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -477,8 +477,8 @@ async def test_run_sync_keeps_changes_requested_for_blocking_review(tmp_db: Path
             ],
         )
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -541,8 +541,8 @@ async def test_run_sync_clears_review_received_after_author_reply(tmp_db: Path, 
             ],
         )
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -615,8 +615,8 @@ async def test_run_sync_keeps_review_received_with_sibling_thread_reply(tmp_db: 
             ],
         )
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -696,8 +696,8 @@ async def test_run_sync_keeps_review_received_when_older_review_is_unresolved(tm
             ],
         )
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -760,8 +760,8 @@ async def test_run_sync_clears_review_received_after_all_threads_resolved(tmp_db
             ],
         )
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -824,8 +824,8 @@ async def test_run_sync_keeps_review_received_after_push_when_feedback_threads_e
             ],
         )
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []
@@ -877,8 +877,8 @@ async def test_run_sync_clears_review_received_after_push_without_feedback_threa
             ],
         )
 
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> list[dict]:
-        return []
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user: str) -> list[dict]:
         return []

--- a/tests/test_syncer_edge_cases.py
+++ b/tests/test_syncer_edge_cases.py
@@ -107,8 +107,8 @@ async def test_run_sync_notification_marks_seen_task_unseen(
             },
         }
 
-    async def fake_discover_review_prs(orgs, gh_user) -> list:
-        return []
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
         return [{
@@ -160,8 +160,8 @@ async def test_run_sync_excludes_repos(tmp_db: Path, monkeypatch) -> None:
             },
         }
 
-    async def fake_discover_review_prs(orgs, gh_user) -> list:
-        return []
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
         return []
@@ -216,8 +216,8 @@ async def test_run_sync_attention_on_status_change_to_approved(
             },
         }
 
-    async def fake_discover_review_prs(orgs, gh_user) -> list:
-        return []
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
         return []
@@ -238,14 +238,51 @@ async def test_run_sync_attention_on_status_change_to_approved(
     assert task["status"] == "approved"
 
 
-async def test_run_sync_closes_review_pr_as_done(
+async def test_run_sync_preserves_tasks_when_repo_fetch_fails(
     tmp_db: Path, monkeypatch,
 ) -> None:
-    """When a review PR disappears from incoming, it should be marked 'done'."""
+    """Tasks should survive when their repo's API call fails."""
     init_db(tmp_db)
-    url = "https://github.com/org/repo/pull/8"
+    url = "https://github.com/org/repo/pull/3"
+    add_task(tmp_db, title="My PR", source="pr_authored", status="open",
+             gh_url=url, gh_repo="org/repo")
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
+        # Simulate API failure — returns empty
+        return {}
+
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_fetch_notifications(gh_user) -> list:
+        return []
+
+    from agendum import gh
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db, AgendumConfig(repos=["org/repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert task is not None
+    assert task["status"] == "open", "Task should not be closed when repo fetch failed"
+
+
+async def test_run_sync_preserves_review_tasks_when_review_fetch_fails(
+    tmp_db: Path, monkeypatch,
+) -> None:
+    """Review tasks should survive when discover_review_prs fails."""
+    init_db(tmp_db)
+    url = "https://github.com/org/repo/pull/9"
     add_task(tmp_db, title="Review PR", source="pr_review", status="review requested",
-             gh_url=url)
+             gh_url=url, gh_repo="org/repo")
 
     async def fake_get_gh_username() -> str:
         return "reviewer"
@@ -264,8 +301,55 @@ async def test_run_sync_closes_review_pr_as_done(
             },
         }
 
-    async def fake_discover_review_prs(orgs, gh_user) -> list:
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], False  # Simulate API failure
+
+    async def fake_fetch_notifications(gh_user) -> list:
         return []
+
+    from agendum import gh
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db, AgendumConfig(repos=["org/repo"]),
+    )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert task is not None
+    assert task["status"] == "review requested", "Review task should not be closed when review fetch failed"
+
+
+async def test_run_sync_closes_review_pr_as_done(
+    tmp_db: Path, monkeypatch,
+) -> None:
+    """When a review PR disappears from incoming, it should be marked 'done'."""
+    init_db(tmp_db)
+    url = "https://github.com/org/repo/pull/8"
+    add_task(tmp_db, title="Review PR", source="pr_review", status="review requested",
+             gh_url=url, gh_repo="org/repo")
+
+    async def fake_get_gh_username() -> str:
+        return "reviewer"
+
+    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
+        return {
+            "data": {
+                "repository": {
+                    "isArchived": False,
+                    "openIssues": {"nodes": []},
+                    "closedIssues": {"nodes": []},
+                    "authoredPRs": {"nodes": []},
+                    "mergedPRs": {"nodes": []},
+                    "closedPRs": {"nodes": []},
+                },
+            },
+        }
+
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
         return []


### PR DESCRIPTION
## Summary
- **Bug**: GitHub-sourced tasks periodically disappeared from the list when API calls failed (rate limit, network hiccup, auth timeout), then reappeared on the next successful sync
- **Root cause**: `diff_tasks()` treated empty API responses as "all items closed on GitHub" and marked them as terminal
- **Fix**: Track which repos returned data successfully (`fetched_repos`) and skip closing tasks from repos that weren't reached. Similarly, skip review task cleanup when `discover_review_prs` fails (new `ok` flag in return tuple).

## Test plan
- [x] New test: tasks survive when repo fetch returns empty (API failure)
- [x] New test: review tasks survive when review discovery fails
- [x] Existing test: review PR still closed as "done" when review fetch succeeds with empty results
- [x] All 180 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)