### PR TITLE
fix: detect re-review requests from timeline events

### DIFF
--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -57,10 +57,11 @@ def derive_review_pr_status(
     *,
     user_has_reviewed: bool,
     new_commits_since_review: bool,
+    re_requested_after_review: bool = False,
 ) -> str:
     if not user_has_reviewed:
         return "review requested"
-    if new_commits_since_review:
+    if re_requested_after_review or new_commits_since_review:
         return "re-review requested"
     return "reviewed"
 
@@ -306,6 +307,16 @@ query($owner: String!, $name: String!, $number: Int!) {
       commits(last: 1) { nodes { commit { committedDate } } }
       reviews(first: 50) {
         nodes { author { login } submittedAt state }
+      }
+      timelineItems(last: 50, itemTypes: [REVIEW_REQUESTED_EVENT]) {
+        nodes {
+          ... on ReviewRequestedEvent {
+            createdAt
+            requestedReviewer {
+              ... on User { login }
+            }
+          }
+        }
       }
     }
   }

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -256,6 +256,7 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
         user_has_reviewed = len(user_reviews) > 0
 
         new_commits_since = False
+        re_requested_after_review = False
         if user_has_reviewed:
             last_review_time = max((r.get("submittedAt") or "" for r in user_reviews), default="")
             last_commit_nodes = pr_detail.get("commits", {}).get("nodes", [])
@@ -263,9 +264,20 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
                 last_commit_time = (last_commit_nodes[0].get("commit", {}).get("committedDate") or "")
                 new_commits_since = last_commit_time > last_review_time
 
+            request_events = pr_detail.get("timelineItems", {}).get("nodes", [])
+            for ev in request_events:
+                reviewer_login = ((ev.get("requestedReviewer") or {}).get("login") or "")
+                if reviewer_login.lower() != gh_user.lower():
+                    continue
+                created_at = ev.get("createdAt") or ""
+                if created_at and created_at > last_review_time:
+                    re_requested_after_review = True
+                    break
+
         status = gh.derive_review_pr_status(
             user_has_reviewed=user_has_reviewed,
             new_commits_since_review=new_commits_since,
+            re_requested_after_review=re_requested_after_review,
         )
 
         author_info = pr_detail.get("author") or {}

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -266,6 +266,14 @@ def test_review_pr_re_review() -> None:
     assert derive_review_pr_status(user_has_reviewed=True, new_commits_since_review=True) == "re-review requested"
 
 
+def test_review_pr_re_review_via_explicit_rerequest() -> None:
+    assert derive_review_pr_status(
+        user_has_reviewed=True,
+        new_commits_since_review=False,
+        re_requested_after_review=True,
+    ) == "re-review requested"
+
+
 def test_issue_open() -> None:
     assert derive_issue_status(state="OPEN", has_linked_pr=False) == "open"
 

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -375,6 +375,111 @@ async def test_run_sync_creates_review_requested_pr_with_author_name(tmp_db: Pat
 
 
 @pytest.mark.asyncio
+async def test_run_sync_flips_reviewed_back_to_re_review_when_re_requested(tmp_db: Path, monkeypatch) -> None:
+    """After user reviews, if the author re-requests them (even without new commits),
+    the status should flip from 'reviewed' back to 're-review requested'."""
+    init_db(tmp_db)
+    url = "https://github.com/example-org/example-repo/pull/77"
+
+    add_task(
+        tmp_db,
+        title="Fix something",
+        source="pr_review",
+        status="reviewed",
+        project="example-repo",
+        gh_repo="example-org/example-repo",
+        gh_url=url,
+        gh_number=77,
+        gh_author="author",
+        gh_author_name="Author",
+        tags='["review"]',
+    )
+
+    async def fake_get_gh_username() -> str:
+        return "reviewer"
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        return {
+            "data": {
+                "repository": {
+                    "isArchived": False,
+                    "openIssues": {"nodes": []},
+                    "closedIssues": {"nodes": []},
+                    "authoredPRs": {"nodes": []},
+                    "mergedPRs": {"nodes": []},
+                    "closedPRs": {"nodes": []},
+                },
+            },
+        }
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        return [
+            {
+                "number": 77,
+                "title": "Fix something",
+                "url": url,
+                "repository": {"nameWithOwner": "example-org/example-repo"},
+                "author": {"login": "author"},
+            }
+        ], True
+
+    async def fake_fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
+        return {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": number,
+                        "title": "Fix something",
+                        "url": url,
+                        "author": {"login": "author", "name": "Author Person"},
+                        # Commit is OLDER than the review (simulates rebase or no-push re-request)
+                        "commits": {"nodes": [{"commit": {"committedDate": "2026-04-05T09:00:00Z"}}]},
+                        "reviews": {
+                            "nodes": [
+                                {
+                                    "author": {"login": "reviewer"},
+                                    "submittedAt": "2026-04-06T10:00:00Z",
+                                    "state": "CHANGES_REQUESTED",
+                                },
+                            ]
+                        },
+                        "timelineItems": {
+                            "nodes": [
+                                {
+                                    "createdAt": "2026-04-07T11:00:00Z",
+                                    "requestedReviewer": {"login": "reviewer"},
+                                },
+                            ]
+                        },
+                    },
+                },
+            },
+        }
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_review_detail", fake_fetch_review_detail)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, _, error = await run_sync(
+        tmp_db,
+        AgendumConfig(repos=["example-org/example-repo"]),
+    )
+
+    tasks = get_active_tasks(tmp_db)
+    assert error is None
+    assert changes >= 1
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "re-review requested"
+
+
+@pytest.mark.asyncio
 async def test_run_sync_sets_authored_pr_to_review_received_for_non_blocking_feedback(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
     url = "https://github.com/example-org/example-repo/pull/12"


### PR DESCRIPTION
## Summary

Review tasks were staying stuck at `reviewed` instead of flipping back to `re-review requested` when the PR author re-requested review.

**Root cause:** The only trigger for `reviewed → re-review requested` was `commit.committedDate > last_review_time`. That misses:
- Author re-requests review without pushing any new commit.
- Author rebases / amends / cherry-picks — `committedDate` is the git commit's date, not the push date, and can be *older* than the user's review.

**Fix:** Pull `ReviewRequestedEvent` items from the PR timeline in the review-detail GraphQL query. If any request event targeting the current user has `createdAt > last review submittedAt`, the task flips to `re-review requested`. The existing commit-time heuristic stays as a fallback.

## Test plan

- [x] New unit test: `derive_review_pr_status` returns `re-review requested` when `re_requested_after_review=True` even with no new commits.
- [x] New integration test: `run_sync` flips an existing `reviewed` task to `re-review requested` when the timeline shows a fresh request event for the user and the latest commit predates the review.
- [x] Full suite green: `uv run pytest` — 182 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)