### PR TITLE
ci: switch releases to rolling release PRs

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -1,0 +1,82 @@
+name: Create Release PR
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: create-release-pr
+  cancel-in-progress: false
+
+jobs:
+  create-release-pr:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      !startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: astral-sh/setup-uv@v6
+
+      - name: Install dev dependencies
+        run: uv sync --dev
+
+      - name: Determine next release version
+        id: next
+        run: |
+          set -euo pipefail
+
+          if NEXT_VERSION=$(uv run cz bump --get-next 2>cz.err); then
+            echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if grep -q "\[NO_COMMITS_TO_BUMP\]" cz.err; then
+            echo "No releasable commits found since the last tag."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if grep -q "No tag matching configuration could be found" cz.err; then
+            echo "No reachable release tag was found from main." >&2
+            echo "Bootstrap the first release manually before relying on release PR automation." >&2
+            cat cz.err >&2
+            exit 1
+          fi
+
+          cat cz.err >&2
+          exit 1
+
+      - name: Prepare release commit contents
+        if: steps.next.outputs.skip != 'true'
+        env:
+          NEXT_VERSION: ${{ steps.next.outputs.next_version }}
+        run: uv run cz bump --yes --changelog --files-only "${NEXT_VERSION}"
+
+      - name: Create or update release PR
+        if: steps.next.outputs.skip != 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: release/next
+          delete-branch: false
+          commit-message: "chore(release): v${{ steps.next.outputs.next_version }}"
+          title: "chore(release): v${{ steps.next.outputs.next_version }}"
+          body: |
+            Automated release PR for `v${{ steps.next.outputs.next_version }}`.
+
+            This PR was created from the latest merged changes on `main` and contains:
+            - version file updates
+            - changelog updates
+
+            This is a rolling release PR. Additional merges to `main` will update this PR in place, including recalculating the release version when needed.
+
+            Merge this PR to publish the GitHub release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,86 +1,58 @@
 name: Release
 
 on:
-  workflow_dispatch:
-    inputs:
-      increment:
-        description: "SemVer increment to apply when version is omitted"
-        required: true
-        default: "patch"
-        type: choice
-        options:
-          - patch
-          - minor
-          - major
-      version:
-        description: "Explicit version override. Use this for the first release or any manual version target."
-        required: false
-        type: string
+  pull_request_target:
+    types: [closed]
 
 permissions:
   contents: write
 
 jobs:
   release:
+    if: >
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'main' &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
 
       - uses: astral-sh/setup-uv@v6
 
-      - name: Ensure workflow runs from main
-        run: |
-          if [ "${GITHUB_REF_NAME}" != "main" ]; then
-            echo "Releases must be run from main." >&2
-            exit 1
-          fi
-
       - name: Install dev dependencies
         run: uv sync --dev
 
-      - name: Configure git author
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-
-      - name: Bump version and create tag
-        env:
-          INPUT_INCREMENT: ${{ inputs.increment }}
-          INPUT_VERSION: ${{ inputs.version }}
+      - name: Determine release version
+        id: version
         run: |
           set -euo pipefail
-
-          if git tag --list 'v*' | grep -q .; then
-            HAS_TAGS=1
-          else
-            HAS_TAGS=0
-          fi
-
-          if [ -n "${INPUT_VERSION}" ]; then
-            uv run cz bump "${INPUT_VERSION}" --yes --changelog --annotated-tag
-          elif [ "${HAS_TAGS}" = "1" ]; then
-            uv run cz bump --yes --changelog --annotated-tag --increment "${INPUT_INCREMENT^^}"
-          else
-            echo "No existing release tags were found." >&2
-            echo "Provide the 'version' input for the first release, for example 0.1.1." >&2
-            exit 1
-          fi
-
-          echo "RELEASE_VERSION=$(uv run cz version --project)" >> "$GITHUB_ENV"
-          echo "RELEASE_TAG=$(uv run cz version --project --tag)" >> "$GITHUB_ENV"
+          echo "release_version=$(uv run cz version --project)" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$(uv run cz version --project --tag)" >> "$GITHUB_OUTPUT"
 
       - name: Build release artifacts
         run: uv build
 
-      - name: Push release commit and tag
-        run: git push origin HEAD:main --follow-tags
-
-      - name: Publish GitHub release
+      - name: Publish tag and GitHub release
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
+          set -euo pipefail
+
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "GitHub release ${RELEASE_TAG} already exists."
+            exit 0
+          fi
+
+          if ! git ls-remote --exit-code --tags origin "refs/tags/${RELEASE_TAG}" >/dev/null 2>&1; then
+            git tag -a "${RELEASE_TAG}" "${MERGE_COMMIT_SHA}" -m "${RELEASE_TAG}"
+            git push origin "${RELEASE_TAG}"
+          fi
+
           gh release create "${RELEASE_TAG}" dist/* \
             --title "${RELEASE_TAG}" \
             --generate-notes

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 
 This repo uses Conventional Commits and SemVer. PR titles should also follow Conventional Commits so squash merges remain release-friendly.
 
-Releases are created manually from the GitHub Actions release workflow on `main`. For the first tagged release, provide an explicit version input because there is no previous release tag yet.
+Merging a non-release PR into `main` creates or updates a rolling `release/next` PR with the version and changelog changes. If more PRs merge into `main` before release, that same release PR is updated in place and its target version is recalculated as needed. Merging the release PR publishes the GitHub tag and release.
+
+The first release still needs a manual bootstrap if `main` does not yet contain a reachable release tag.
+
+If you still have an older open release PR from a versioned branch such as `release/v0.1.1`, that PR will not be updated by the rolling workflow. The rolling workflow only updates the PR backed by `release/next`.
 
 ## Usage
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 
+from agendum import __version__
 from agendum import __main__ as main
 
 
@@ -31,7 +32,7 @@ def test_main_version_flag_prints_version(capsys: pytest.CaptureFixture[str], mo
         main.main()
 
     assert exc_info.value.code == 0
-    assert capsys.readouterr().out.strip() == "agendum 0.1.0"
+    assert capsys.readouterr().out.strip() == f"agendum {__version__}"
 
 
 def test_self_check_initializes_storage_and_prints_ok(


### PR DESCRIPTION
## Summary
- create a rolling release PR workflow on merges to main
- publish releases only after merging the rolling release PR
- document the new release model and remove the stale hardcoded version assertion

## Testing
- uv run pytest -q