### PR TITLE
ci: skip release PR creation until metadata is synced

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -35,6 +35,15 @@ jobs:
         run: |
           set -euo pipefail
 
+          CURRENT_VERSION=$(uv run cz version --project)
+          CURRENT_TAG="v${CURRENT_VERSION}"
+
+          if ! git tag --list "${CURRENT_TAG}" | grep -q . && git tag --list 'v*' | grep -q .; then
+            echo "::notice::Skipping release PR creation because main is still at ${CURRENT_VERSION} while later release tags already exist. Sync the prior release metadata onto main first."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if NEXT_VERSION=$(uv run cz bump --get-next 2>cz.err); then
             echo "next_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
             exit 0


### PR DESCRIPTION
## Summary
- stop the post-merge release workflow from failing when main is still behind the last released version metadata
- emit a notice and skip release PR creation until the prior release metadata has been synced onto main

## Why
The current main branch is still at version 0.1.0, while tag v0.1.1 exists off-main from the earlier recovery path. Commitizen treats that as a bootstrap case and prompts interactively, which crashes in Actions.

## Testing
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/create-release-pr.yml")'