### PR TITLE
chore: sync v0.1.1 release metadata to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+## v0.1.1 (2026-04-16)
+
+### Feat
+
+- add release discipline and packaging scaffolding
+- add max retry limit for wake sync retries
+- implement retry-with-backoff after wake from sleep
+- replace monotonic-only sleep detection with wall-vs-monotonic drift
+- **ui**: wrap title column instead of truncating
+- **ui**: right-align link column in task table
+- agendum — terminal dashboard for GitHub tasks
+
+### Fix
+
+- discard stale backoff timers after suspended state is cleared
+- force-sync overrides suspended state, refresh status on retry exhaustion
+- prevent periodic sync timer from forking wake-retry chain
+- **sync**: handle null timestamps in review comparison
+- **ui**: increase selected row contrast
+- **ui**: restore cursor position after table refresh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "agendum"
-version = "0.1.0"
+version = "0.1.1"
 description = "Terminal dashboard for GitHub PRs, issues, and tasks"
 license = "Apache-2.0"
 requires-python = ">=3.11"

--- a/src/agendum/__init__.py
+++ b/src/agendum/__init__.py
@@ -1,3 +1,3 @@
 """Agendum — terminal dashboard for GitHub tasks."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agendum"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- sync the existing v0.1.1 release metadata onto current main
- add CHANGELOG.md for v0.1.1
- bump project metadata from 0.1.0 to 0.1.1 in versioned files

## Why
The v0.1.1 tag already exists, but main never received the matching version/changelog commit from the earlier release recovery flow. This PR performs that one-time bootstrap sync so the rolling release workflow can operate from main.

## Testing
- uv run pytest -q