### PR TITLE
fix(release): harden release-next publish flow

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -5,6 +5,7 @@ on:
     types: [closed]
 
 permissions:
+  actions: write
   contents: write
   pull-requests: write
 
@@ -89,3 +90,9 @@ jobs:
             This is a rolling release PR. Additional merges to `main` will update this PR in place, including recalculating the release version when needed.
 
             Merge this PR to publish the GitHub release.
+
+      - name: Trigger validation workflow for release PR
+        if: steps.next.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run validation.yml --ref release/next

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -58,7 +58,7 @@ jobs:
 
           if grep -q "No tag matching configuration could be found" cz.err; then
             echo "No reachable release tag was found from main." >&2
-            echo "Bootstrap the first release manually before relying on release PR automation." >&2
+            echo "Bootstrap the first release tag once, then the rolling release PR flow takes over." >&2
             cat cz.err >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,11 @@ permissions:
 
 jobs:
   release:
+    # Semantic guard: only the merged rolling release PR on release/next may publish.
     if: >
       github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'main' &&
-      startsWith(github.event.pull_request.head.ref, 'release/')
+      github.event.pull_request.head.ref == 'release/next'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -1,10 +1,11 @@
-name: Test
+name: Validation
 
 on:
   push:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   validation:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,18 +49,26 @@ Examples:
 
 ## Releases
 
-Releases are operator-triggered from GitHub Actions, not on every merge.
+Releases follow the rolling `release/next` PR model.
 
-The release workflow:
+The release PR workflow:
 
-- runs only from `main`
+- runs when a merged PR lands on `main`
 - bumps the version with `commitizen`
 - updates `CHANGELOG.md`
+- keeps a single `release/next` branch updated in place
+- triggers validation for the release PR
+
+The publish workflow:
+
+- runs only when the merged PR head branch is exactly `release/next`
 - creates an annotated git tag
 - builds `sdist` and wheel artifacts with `uv build`
 - publishes a GitHub release
 
-For the first release, provide an explicit `version` input because there is no prior tag history yet.
+For the first release, bootstrap one reachable release tag if none exists yet, then the rolling release PR automation takes over.
+
+See [docs/release-hardening.md](docs/release-hardening.md) for the required GitHub rulesets and token permissions.
 
 ## Packaging Notes
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,10 @@ This repo uses Conventional Commits and SemVer. PR titles should also follow Con
 
 Merging a non-release PR into `main` creates or updates a rolling `release/next` PR with the version and changelog changes. If more PRs merge into `main` before release, that same release PR is updated in place and its target version is recalculated as needed. Merging the release PR publishes the GitHub tag and release.
 
-The first release still needs a manual bootstrap if `main` does not yet contain a reachable release tag.
+The first release still needs a one-time bootstrap tag if `main` does not yet contain a reachable release tag.
 
 If you still have an older open release PR from a versioned branch such as `release/v0.1.1`, that PR will not be updated by the rolling workflow. The rolling workflow only updates the PR backed by `release/next`.
+See [docs/release-hardening.md](docs/release-hardening.md) for the required GitHub rulesets and workflow permissions.
 
 ## Usage
 

--- a/docs/homebrew-release-discipline-plan.md
+++ b/docs/homebrew-release-discipline-plan.md
@@ -117,16 +117,16 @@ Automate SemVer-based tagging and GitHub release publication from Conventional C
 ### Tasks
 
 - [x] Decide release automation shape:
-  - manual operator-triggered release workflow
+  - rolling `release/next` release PR workflow
   - `commitizen` performs SemVer bumping, changelog, and tagging
 - [x] Configure changelog generation
 - [ ] Standardize where version is sourced from and updated
 - [x] Add GitHub Actions workflow for release creation
-- [x] Define manual release operator flow in docs
+- [x] Define rolling release PR and bootstrap flow in docs
 
 ### Preferred Direction
 
-Use a workflow that derives release bumps from Conventional Commits when manually triggered from `main`.
+Use a workflow that derives release bumps from Conventional Commits and promotes them through a rolling `release/next` PR.
 
 ### Open Implementation Detail
 

--- a/docs/release-hardening.md
+++ b/docs/release-hardening.md
@@ -1,0 +1,36 @@
+# Release Hardening
+
+This repository uses a rolling release PR model:
+
+1. Merges to `main` can update `release/next`.
+2. Merging `release/next` publishes the tagged GitHub release.
+3. The first release still needs a bootstrap tag if the repository has no reachable release tag yet.
+
+## Required GitHub rulesets
+
+Configure these in repository settings:
+
+- Branch ruleset for `release/next`
+  - exact branch name: `release/next`
+  - protect it so only the release automation and approved maintainers can update or merge it
+- Tag ruleset for `v*`
+  - exact pattern: `v*`
+  - protect release tags from direct edits or deletes outside the release workflow
+
+The workflow conditions remain the final semantic guard. Rulesets reduce accidental writes, but `release.yml` still only publishes when the merged pull request head branch is exactly `release/next`.
+
+## Workflow token permissions
+
+The release workflow assumes `GITHUB_TOKEN` has:
+
+- `contents: write` to create the annotated tag and publish the GitHub release
+
+The rolling release PR workflow also needs repository write permissions for:
+
+- `contents: write`
+- `pull-requests: write`
+- `actions: write` to dispatch validation on `release/next`
+
+## Bootstrap flow
+
+If `create-release-pr.yml` cannot find a reachable prior release tag, bootstrap the first release tag once. After that, the automation keeps `release/next` moving and the publish workflow handles the release on merge.

--- a/tests/test_release_workflow_docs.py
+++ b/tests/test_release_workflow_docs.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_release_workflow_only_publishes_from_release_next() -> None:
+    release_workflow = (ROOT / ".github/workflows/release.yml").read_text()
+
+    assert "github.event.pull_request.head.ref == 'release/next'" in release_workflow
+    assert "startsWith(github.event.pull_request.head.ref, 'release/')" not in release_workflow
+
+
+def test_create_release_pr_documents_bootstrap_path() -> None:
+    create_release_pr = (ROOT / ".github/workflows/create-release-pr.yml").read_text()
+
+    assert "release/next" in create_release_pr
+    assert "Bootstrap the first release tag once" in create_release_pr
+
+
+def test_release_hardening_doc_covers_rulesets_and_permissions() -> None:
+    hardening_doc = (ROOT / "docs/release-hardening.md").read_text()
+
+    assert "exact branch name: `release/next`" in hardening_doc
+    assert "exact pattern: `v*`" in hardening_doc
+    assert "`contents: write`" in hardening_doc
+    assert "final semantic guard" in hardening_doc


### PR DESCRIPTION
## Summary
- restrict release publication to merged PRs whose head branch is exactly `release/next`
- keep the first-release bootstrap path and clarify that the rolling release PR flow takes over after one reachable tag exists
- document the rolling `release/next` model, required GitHub rulesets, and workflow-token permissions
- add lightweight tests that lock in the workflow gate and hardening docs

## Testing
- uv run pytest -q tests/test_release_workflow_docs.py
- uv run pytest -q

## External Follow-up
- add an exact branch ruleset for `release/next`
- add a tag ruleset for `v*`
- ensure repo workflow permissions allow the documented `GITHUB_TOKEN` writes