### PR TITLE
feat: dispatch homebrew tap after published releases

### DIFF
--- a/.github/workflows/dispatch-homebrew-tap.yml
+++ b/.github/workflows/dispatch-homebrew-tap.yml
@@ -1,0 +1,51 @@
+name: Dispatch Homebrew Tap
+
+on:
+  release:
+    types: [published]
+
+permissions: {}
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+      TARGET_REPO: danseely/homebrew-tap
+      DISPATCH_EVENT_TYPE: agendum_release_published
+      SOURCE_REPO: ${{ github.repository }}
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      RELEASE_URL: ${{ github.event.release.html_url }}
+      TARBALL_URL: ${{ github.event.release.tarball_url }}
+      PUBLISHED_AT: ${{ github.event.release.published_at }}
+    steps:
+      - name: Dispatch release metadata to Homebrew tap
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${GH_TOKEN:-}" ]]; then
+            echo "HOMEBREW_TAP_DISPATCH_TOKEN is required to dispatch to ${TARGET_REPO}." >&2
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+
+          echo "Dispatching ${DISPATCH_EVENT_TYPE} to ${TARGET_REPO}."
+          if ! dispatch_output=$(gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${TARGET_REPO}/dispatches" \
+            -f event_type="${DISPATCH_EVENT_TYPE}" \
+            -F client_payload[source_repo]="${SOURCE_REPO}" \
+            -F client_payload[tag]="${RELEASE_TAG}" \
+            -F client_payload[version]="${VERSION}" \
+            -F client_payload[release_url]="${RELEASE_URL}" \
+            -F client_payload[tarball_url]="${TARBALL_URL}" \
+            -F client_payload[published_at]="${PUBLISHED_AT}" 2>&1); then
+            echo "Dispatch to ${TARGET_REPO} with event ${DISPATCH_EVENT_TYPE} failed." >&2
+            echo "${dispatch_output}" >&2
+            exit 1
+          fi
+
+          echo "Dispatch to ${TARGET_REPO} with event ${DISPATCH_EVENT_TYPE} succeeded."

--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 This repo uses Conventional Commits and SemVer. PR titles should also follow Conventional Commits so squash merges remain release-friendly.
 
 Merging a non-release PR into `main` creates or updates a rolling `release/next` PR with the version and changelog changes. If more PRs merge into `main` before release, that same release PR is updated in place and its target version is recalculated as needed. Merging the release PR publishes the GitHub tag and release.
+Publishing the GitHub release also dispatches `repository_dispatch` to `danseely/homebrew-tap` so the Homebrew tap can update from the release payload.
 
 The first release still needs a one-time bootstrap tag if `main` does not yet contain a reachable release tag.
 

--- a/docs/release-hardening.md
+++ b/docs/release-hardening.md
@@ -31,6 +31,26 @@ The rolling release PR workflow also needs repository write permissions for:
 - `pull-requests: write`
 - `actions: write` to dispatch validation on `release/next`
 
+## Homebrew tap dispatch
+
+After `release.yml` publishes a GitHub release, `.github/workflows/dispatch-homebrew-tap.yml` runs on the `release.published` event and sends a `repository_dispatch` to `danseely/homebrew-tap`.
+
+Use a dedicated repo secret named `HOMEBREW_TAP_DISPATCH_TOKEN` for the dispatch call. Keep that token scoped only to the tap repo and the `repository_dispatch` API path it needs; do not reuse `GITHUB_TOKEN` for cross-repo automation.
+
+The dispatch contract is:
+
+- `event_type`: `agendum_release_published`
+- `client_payload.source_repo`: `danseely/agendum`
+- `client_payload.tag`: the raw release tag, for example `v0.1.0`
+- `client_payload.version`: the SemVer string without the leading `v`, for example `0.1.0`
+- `client_payload.release_url`: the GitHub release URL
+- `client_payload.tarball_url`: the release tarball URL from GitHub
+- `client_payload.published_at`: the release publication timestamp
+
+Sequencing matters: the tap should treat `repository_dispatch` as the signal that the GitHub release already exists and can be consumed from the release URLs above. The tap should not assume source artifacts are available before the dispatch arrives.
+
+Operational fallback: if dispatch fails, rerun the `Dispatch Homebrew Tap` workflow from the Actions UI. If the workflow is unavailable, trigger the tap manually with the same `repository_dispatch` payload using `gh api` and the same token.
+
 ## Bootstrap flow
 
 If `create-release-pr.yml` cannot find a reachable prior release tag, bootstrap the first release tag once. After that, the automation keeps `release/next` moving and the publish workflow handles the release on merge.


### PR DESCRIPTION
## Summary
- add a release.published workflow that dispatches release metadata to danseely/homebrew-tap
- document the dispatch contract, required secret, sequencing, and fallback path
- mention the downstream Homebrew handoff in the main release flow docs

Closes #28