### PR TITLE
fix: configure git identity before tagging releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Build release artifacts
         run: uv build
 
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: Publish tag and GitHub release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary
- configure a git identity on the runner before creating the annotated release tag
- keep the existing release publication flow unchanged otherwise

This fixes the release failure from run 24593842722, which died creating the tag with no configured git identity.