### PR TITLE
docs: document maintainer release flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ The first release still needs a one-time bootstrap tag if `main` does not yet co
 If you still have an older open release PR from a versioned branch such as `release/v0.1.1`, that PR will not be updated by the rolling workflow. The rolling workflow only updates the PR backed by `release/next`.
 See [docs/release-hardening.md](docs/release-hardening.md) for the required GitHub rulesets and workflow permissions.
 
+### Release checklist
+
+From a maintainer point of view, the normal release flow is:
+
+1. Merge feature PRs into `main`.
+2. Let the automation create or update the rolling `release/next` PR.
+3. Review the `release/next` PR and wait for its validation check to pass.
+4. Merge `release/next` when you want to ship.
+5. Wait for the `Release` workflow to publish the GitHub tag and release.
+6. Wait for the `Dispatch Homebrew Tap` workflow to notify `danseely/homebrew-tap`.
+7. Review and merge the Homebrew tap release PR after its CI passes.
+8. If you want the separate Homebrew `pr-pull` publish path, trigger that in the tap after the release PR merge.
+
+You should not normally need to run the tap workflow by hand. Manual replay is only for missed dispatches, failed automation, or debugging.
+
 ## Usage
 
 ```bash

--- a/docs/release-hardening.md
+++ b/docs/release-hardening.md
@@ -6,6 +6,20 @@ This repository uses a rolling release PR model:
 2. Merging `release/next` publishes the tagged GitHub release.
 3. The first release still needs a bootstrap tag if the repository has no reachable release tag yet.
 
+## Maintainer flow
+
+The normal operator flow is:
+
+1. Merge releasable work into `main`.
+2. Review the rolling `release/next` PR created or updated by automation.
+3. Merge `release/next` when ready to ship.
+4. Confirm that `release.yml` publishes the GitHub tag and release.
+5. Confirm that `dispatch-homebrew-tap.yml` dispatches the release payload to `danseely/homebrew-tap`.
+6. Review and merge the resulting tap PR after Homebrew CI passes.
+7. Trigger the tap's separate `pr-pull` publish path if you want bottles/publish handled through the standard Homebrew flow.
+
+The tap release PR is part of the release path now. The code repository release is not complete until the corresponding tap PR is green and merged.
+
 ## Required GitHub rulesets
 
 Configure these in repository settings:


### PR DESCRIPTION
## Summary
Document the maintainer-facing release checklist in the main README and the release hardening runbook.

## Why
The automation shape was documented, but the operator flow from merging feature work through the tap PR was not written down clearly in one maintainer-facing checklist.

## Validation
Docs-only change; no tests run.