### PR TITLE
fix: sync uv.lock package version

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agendum"
-version = "0.1.1"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
Sync the editable root package version in uv.lock from 0.1.1 to 0.2.0.

## Why
pyproject.toml and the current release state are already at 0.2.0, but uv.lock on main still recorded the root package as 0.1.1. This keeps the lockfile metadata consistent with the project version.

## Validation
Reviewed the one-line uv.lock diff only; no tests run.