### PR TITLE
feat: add isolated GitHub namespace switching

### DIFF
--- a/review-fix-plan.md
+++ b/review-fix-plan.md
@@ -1,0 +1,97 @@
+# PR 36 Follow-up Fix Plan
+
+## 1. Repo-only review discovery
+
+Make review-task cleanup aware that `orgs=[]` in a repo-only workspace does not mean review discovery was complete.
+
+Safest short fix:
+
+- mark review discovery incomplete for repo-only configs unless there is an actual repo-scoped review discovery path
+- preserve existing `pr_review` rows instead of closing them on false completeness
+- keep authored PR, issue, and manual task cleanup behavior unchanged
+
+Regression test:
+
+- repo-only workspace preserves existing `pr_review` rows after sync when no org-scoped review query ran
+
+Likely touch points:
+
+- `src/agendum/syncer.py`
+- `tests/test_syncer_edge_cases.py`
+
+## 2. Auth source ordering for namespace creation
+
+Change namespace switching so recovery tries auth sources in this order:
+
+1. target workspace auth
+2. current workspace auth
+3. default/global `gh` auth
+4. interactive login
+
+This keeps agendum-local authenticated state reusable even when `~/.config/gh` is stale or empty.
+
+Regression test:
+
+- creating a new namespace reuses current workspace auth when global `gh` auth is stale
+
+Likely touch points:
+
+- `src/agendum/app.py`
+- `src/agendum/gh.py`
+- `tests/test_app_interaction.py`
+- `tests/test_gh.py`
+
+## 3. Base-workspace return symmetry
+
+Remove the asymmetry that skips auth recovery when returning to base.
+
+Returning to base should go through the same recovery logic as entering a namespace, targeting the base workspace auth dir and falling back to interactive login only if recovery fails.
+
+Regression test:
+
+- returning to base recovers base auth instead of skipping auth handling
+
+Likely touch points:
+
+- `src/agendum/app.py`
+- `tests/test_app_interaction.py`
+
+## 4. Reauth semantics
+
+Separate "recover if broken" from "refresh/reauth on demand."
+
+`agendum reauth` should not short-circuit just because workspace auth is currently valid. It should either:
+
+- refresh from the preferred upstream auth source if available, or
+- force interactive reauth when requested or needed
+
+This makes the command useful after account or token changes.
+
+Regression test:
+
+- `agendum reauth` refreshes even when workspace auth already exists
+
+Likely touch points:
+
+- `src/agendum/__main__.py`
+- `src/agendum/gh.py`
+- `tests/test_main.py`
+- `tests/test_gh.py`
+
+## 5. Validation sequence
+
+After implementation:
+
+1. run the focused auth and sync regression tests first
+2. run full `uv run pytest`
+3. do one final targeted review only against these four invariants, not another broad free-form pass
+
+Suggested focused pass:
+
+- `uv run pytest tests/test_syncer_edge_cases.py tests/test_app_interaction.py tests/test_main.py tests/test_gh.py`
+
+Implementation guardrails:
+
+- keep fixes minimal and local to the auth/sync paths above
+- prefer adding small helpers over widening CLI or app behavior
+- do not change unrelated namespace/config defaults while addressing these items

--- a/src/agendum/__main__.py
+++ b/src/agendum/__main__.py
@@ -4,39 +4,34 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 from pathlib import Path
 
 from agendum import __version__
 from agendum.config import CONFIG_DIR, CONFIG_PATH, DB_PATH, DEFAULT_CONFIG, ensure_config, runtime_paths
 from agendum.demo import run_demo_screenshots
-from agendum.gh import seed_gh_config_dir
+from agendum.gh import auth_status, recover_gh_auth
 
 
-def check_gh_cli() -> bool:
-    """Verify gh CLI is installed and authenticated."""
-    try:
-        result = subprocess.run(
-            ["gh", "auth", "status"],
-            capture_output=True,
-            text=True,
-        )
-        return result.returncode == 0
-    except FileNotFoundError:
-        return False
+def check_gh_cli(gh_config_dir: Path | None = None) -> bool:
+    """Verify gh CLI is installed and authenticated for a config dir."""
+    return auth_status(gh_config_dir)
 
 
-def first_run_setup(config_path: Path | None = None) -> None:
+def first_run_setup(
+    config_path: Path | None = None,
+    gh_config_dir: Path | None = None,
+) -> None:
     """Interactive first-run setup."""
     config_path = config_path or CONFIG_PATH
+    gh_config_dir = gh_config_dir or runtime_paths(config_path.parent).gh_config_dir
     print("Welcome to agendum!")
     print()
 
-    if not check_gh_cli():
+    if not recover_gh_auth(gh_config_dir, interactive=True):
         print("Error: gh CLI is not installed or not authenticated.")
         print("Install: https://cli.github.com/")
-        print("Then run: gh auth login")
+        print(f"Then run: GH_CONFIG_DIR={gh_config_dir} gh auth login")
         sys.exit(1)
 
     if not config_path.exists():
@@ -91,6 +86,10 @@ def main() -> None:
         "demo-screenshots",
         help="launch a disposable seeded workspace for README screenshots",
     )
+    subparsers.add_parser(
+        "reauth",
+        help="refresh the base workspace gh auth from local/default state or interactive login",
+    )
     args = parser.parse_args()
 
     if args.command == "self-check":
@@ -103,10 +102,19 @@ def main() -> None:
 
     paths = runtime_paths(CONFIG_DIR)
 
-    if not paths.config_path.exists() or not paths.db_path.exists():
-        first_run_setup(paths.config_path)
+    if args.command == "reauth":
+        if not recover_gh_auth(paths.gh_config_dir, interactive=True):
+            print("Error: gh CLI is not installed or not authenticated.")
+            print("Install: https://cli.github.com/")
+            print(f"Then run: GH_CONFIG_DIR={paths.gh_config_dir} gh auth login")
+            sys.exit(1)
+        print(f"Workspace gh auth ready at {paths.gh_config_dir}")
+        return
 
-    seed_gh_config_dir(paths.gh_config_dir)
+    if not paths.config_path.exists() or not paths.db_path.exists():
+        first_run_setup(paths.config_path, paths.gh_config_dir)
+
+    recover_gh_auth(paths.gh_config_dir)
     config = ensure_config(paths.config_path)
 
     from agendum.app import AgendumApp

--- a/src/agendum/__main__.py
+++ b/src/agendum/__main__.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 from agendum import __version__
-from agendum.config import CONFIG_DIR, CONFIG_PATH, DB_PATH, DEFAULT_CONFIG, ensure_config
+from agendum.config import CONFIG_DIR, CONFIG_PATH, DB_PATH, DEFAULT_CONFIG, ensure_config, runtime_paths
 from agendum.demo import run_demo_screenshots
 
 
@@ -100,16 +100,18 @@ def main() -> None:
         run_demo_screenshots()
         return
 
-    if not CONFIG_PATH.exists() or not DB_PATH.exists():
-        first_run_setup()
+    paths = runtime_paths(CONFIG_DIR)
 
-    config = ensure_config()
+    if not paths.config_path.exists() or not paths.db_path.exists():
+        first_run_setup(paths.config_path)
+
+    config = ensure_config(paths.config_path)
 
     from agendum.app import AgendumApp
     from agendum.db import init_db
 
-    init_db(DB_PATH)
-    app = AgendumApp(db_path=DB_PATH, config=config)
+    init_db(paths.db_path)
+    app = AgendumApp(runtime=paths, config=config)
     app.run()
 
 

--- a/src/agendum/__main__.py
+++ b/src/agendum/__main__.py
@@ -103,7 +103,7 @@ def main() -> None:
     paths = runtime_paths(CONFIG_DIR)
 
     if args.command == "reauth":
-        if not recover_gh_auth(paths.gh_config_dir, interactive=True):
+        if not recover_gh_auth(paths.gh_config_dir, interactive=True, force_refresh=True):
             print("Error: gh CLI is not installed or not authenticated.")
             print("Install: https://cli.github.com/")
             print(f"Then run: GH_CONFIG_DIR={paths.gh_config_dir} gh auth login")

--- a/src/agendum/__main__.py
+++ b/src/agendum/__main__.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from agendum import __version__
 from agendum.config import CONFIG_DIR, CONFIG_PATH, DB_PATH, DEFAULT_CONFIG, ensure_config, runtime_paths
 from agendum.demo import run_demo_screenshots
+from agendum.gh import seed_gh_config_dir
 
 
 def check_gh_cli() -> bool:
@@ -105,6 +106,7 @@ def main() -> None:
     if not paths.config_path.exists() or not paths.db_path.exists():
         first_run_setup(paths.config_path)
 
+    seed_gh_config_dir(paths.gh_config_dir)
     config = ensure_config(paths.config_path)
 
     from agendum.app import AgendumApp

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -28,7 +28,7 @@ from agendum.config import (
     RuntimePaths,
     default_runtime_paths,
     ensure_workspace_config,
-    namespace_runtime_paths,
+    workspace_runtime_paths,
     runtime_base_dir,
     runtime_paths,
 )
@@ -176,6 +176,7 @@ class AgendumApp(App):
         self._sync_timer: Timer | None = None
         self._spinner_timer: Timer | None = None
         self._status_timer: Timer | None = None
+        self._seen_timer: Timer | None = None
         self._sync_context_id = 0
 
     @property
@@ -188,6 +189,8 @@ class AgendumApp(App):
 
     @property
     def current_namespace(self) -> str | None:
+        if self._runtime.workspace_root == self._workspace_base_dir:
+            return None
         if self._config and self._config.orgs:
             return self._config.orgs[0]
         return None
@@ -471,10 +474,13 @@ class AgendumApp(App):
         """Show the command input for namespace switching."""
         self._show_input(
             mode="namespace",
-            placeholder="GitHub namespace to switch into…",
+            placeholder="GitHub namespace (blank for base workspace)…",
             value=self.current_namespace or "",
         )
-        self.notify("Type a GitHub namespace, then Enter to re-auth", timeout=3)
+        self.notify(
+            "Enter a GitHub namespace, or submit blank for the base workspace",
+            timeout=3,
+        )
 
     def action_cancel_input(self) -> None:
         """Hide the create-input and return focus to the table."""
@@ -537,43 +543,49 @@ class AgendumApp(App):
     # ── task creation via input ──────────────────────────────────────
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
+        mode = self._input_mode
         value = event.value.strip()
-        if not value:
+        if mode != "namespace" and not value:
             self.action_cancel_input()
             return
-        mode = self._input_mode
         self.action_cancel_input()
         if mode == "namespace":
-            self._switch_namespace(value)
+            self._switch_namespace(value or None)
             return
 
         add_task(self._db_path, title=value, source="manual", status="active")
         self.refresh_table()
 
-    def _switch_namespace(self, namespace: str) -> None:
+    def _switch_namespace(self, namespace: str | None) -> None:
         try:
-            target_runtime = namespace_runtime_paths(namespace, self._workspace_base_dir)
-        except ValueError:
+            target_runtime = workspace_runtime_paths(namespace, self._workspace_base_dir)
+        except ValueError as exc:
             self.notify(
-                "Invalid namespace: enter at least one letter or number.",
+                f"Invalid namespace: {str(exc).rstrip('.')}.",
                 severity="error",
                 timeout=5,
             )
             return
-        with self.suspend():
-            authenticated = auth_login(target_runtime.gh_config_dir)
-        if not authenticated:
-            self._sync_error = "gh auth login failed"
-            self._update_status_bar()
+
+        if target_runtime == self._runtime:
             return
+
+        target_namespace = namespace or None
+        if target_runtime.workspace_root != self._workspace_base_dir:
+            with self.suspend():
+                authenticated = auth_login(target_runtime.gh_config_dir)
+            if not authenticated:
+                self._sync_error = "gh auth login failed"
+                self._update_status_bar()
+                return
 
         config = ensure_workspace_config(
             target_runtime,
-            namespace=namespace,
+            namespace=target_namespace,
             seed=self._config,
         )
         self._apply_runtime(target_runtime, config)
-        self.notify(f"Switched to {namespace}", timeout=3)
+        self.notify(f"Switched to {target_namespace or 'base workspace'}", timeout=3)
 
     def _apply_runtime(self, runtime: RuntimePaths, config: AgendumConfig) -> None:
         self._runtime = runtime
@@ -582,6 +594,7 @@ class AgendumApp(App):
         self._config = config
         init_db(self._db_path)
         self._sync_context_id += 1
+        self._cancel_seen_timer()
         self._last_sync = None
         self._sync_error = None
         self._sync_in_progress = False
@@ -749,11 +762,32 @@ class AgendumApp(App):
 
     def on_app_focus(self) -> None:
         self._app_focused = True
-        if self._config:
-            self.set_timer(self._config.seen_delay, self._mark_seen)
+        self._schedule_mark_seen()
 
     def on_app_blur(self) -> None:
         self._app_focused = False
+        self._cancel_seen_timer()
+
+    def _schedule_mark_seen(self) -> None:
+        self._cancel_seen_timer()
+        if self._config is None:
+            return
+
+        sync_context_id = self._sync_context_id
+        db_path = self._db_path
+
+        def mark_seen_for_context() -> None:
+            if sync_context_id == self._sync_context_id:
+                self._seen_timer = None
+            self._mark_seen(db_path, sync_context_id)
+
+        self._seen_timer = self.set_timer(self._config.seen_delay, mark_seen_for_context)
+
+    def _cancel_seen_timer(self) -> None:
+        if self._seen_timer is None:
+            return
+        self._seen_timer.stop()
+        self._seen_timer = None
 
     def _disable_focus_reporting(self) -> None:
         try:
@@ -763,9 +797,10 @@ class AgendumApp(App):
             pass
 
     def on_unmount(self) -> None:
+        self._cancel_seen_timer()
         self._disable_focus_reporting()
 
-    def _mark_seen(self) -> None:
-        if self._app_focused:
-            mark_all_seen(self._db_path)
+    def _mark_seen(self, db_path: Path, sync_context_id: int) -> None:
+        if self._app_focused and sync_context_id == self._sync_context_id:
+            mark_all_seen(db_path)
             self.refresh_table()

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -551,7 +551,15 @@ class AgendumApp(App):
         self.refresh_table()
 
     def _switch_namespace(self, namespace: str) -> None:
-        target_runtime = namespace_runtime_paths(namespace, self._workspace_base_dir)
+        try:
+            target_runtime = namespace_runtime_paths(namespace, self._workspace_base_dir)
+        except ValueError:
+            self.notify(
+                "Invalid namespace: enter at least one letter or number.",
+                severity="error",
+                timeout=5,
+            )
+            return
         with self.suspend():
             authenticated = auth_login(target_runtime.gh_config_dir)
         if not authenticated:

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -40,7 +40,7 @@ from agendum.db import (
     remove_task,
     update_task,
 )
-from agendum.gh import auth_login, set_gh_config_dir
+from agendum.gh import auth_login, recover_gh_auth, set_gh_config_dir
 from agendum.syncer import run_sync
 from agendum.widgets import (
     ActionModal,
@@ -191,6 +191,8 @@ class AgendumApp(App):
     def current_namespace(self) -> str | None:
         if self._runtime.workspace_root == self._workspace_base_dir:
             return None
+        if self._runtime.workspace_root.parent.name == "workspaces":
+            return self._runtime.workspace_root.name
         if self._config and self._config.orgs:
             return self._config.orgs[0]
         return None
@@ -572,12 +574,13 @@ class AgendumApp(App):
 
         target_namespace = namespace or None
         if target_runtime.workspace_root != self._workspace_base_dir:
-            with self.suspend():
-                authenticated = auth_login(target_runtime.gh_config_dir)
-            if not authenticated:
-                self._sync_error = "gh auth login failed"
-                self._update_status_bar()
-                return
+            if not recover_gh_auth(target_runtime.gh_config_dir):
+                with self.suspend():
+                    authenticated = auth_login(target_runtime.gh_config_dir)
+                if not authenticated:
+                    self._sync_error = "gh auth login failed"
+                    self._update_status_bar()
+                    return
 
         config = ensure_workspace_config(
             target_runtime,
@@ -606,6 +609,8 @@ class AgendumApp(App):
         if self._sync_timer is not None:
             self._sync_timer.stop()
             self._sync_timer = self.set_interval(self._config.sync_interval, self._start_sync)
+        if self._app_focused:
+            self._schedule_mark_seen()
         self.refresh_table()
         self._update_status_bar()
         self._start_sync()

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -573,14 +573,16 @@ class AgendumApp(App):
             return
 
         target_namespace = namespace or None
-        if target_runtime.workspace_root != self._workspace_base_dir:
-            if not recover_gh_auth(target_runtime.gh_config_dir):
-                with self.suspend():
-                    authenticated = auth_login(target_runtime.gh_config_dir)
-                if not authenticated:
-                    self._sync_error = "gh auth login failed"
-                    self._update_status_bar()
-                    return
+        if not recover_gh_auth(
+            target_runtime.gh_config_dir,
+            source_dir=self._runtime.gh_config_dir,
+        ):
+            with self.suspend():
+                authenticated = auth_login(target_runtime.gh_config_dir)
+            if not authenticated:
+                self._sync_error = "gh auth login failed"
+                self._update_status_bar()
+                return
 
         config = ensure_workspace_config(
             target_runtime,

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -9,6 +9,7 @@ import time
 import webbrowser
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
 
 log = logging.getLogger(__name__)
 
@@ -17,11 +18,20 @@ from textual import events
 from textual.app import App, ComposeResult
 from textual.app import ScreenStackError
 from textual.binding import Binding
+from textual.timer import Timer
 from textual.widgets import DataTable, Footer, Input, Static
 from textual.widgets._data_table import ColumnKey
 from textual.worker import Worker, WorkerState
 
-from agendum.config import AgendumConfig, DB_PATH, ensure_config
+from agendum.config import (
+    AgendumConfig,
+    RuntimePaths,
+    default_runtime_paths,
+    ensure_workspace_config,
+    namespace_runtime_paths,
+    runtime_base_dir,
+    runtime_paths,
+)
 from agendum.db import (
     add_task,
     get_active_tasks,
@@ -30,6 +40,7 @@ from agendum.db import (
     remove_task,
     update_task,
 )
+from agendum.gh import auth_login, set_gh_config_dir
 from agendum.syncer import run_sync
 from agendum.widgets import (
     ActionModal,
@@ -122,17 +133,32 @@ class AgendumApp(App):
         Binding("q", "quit", "Quit"),
         Binding("r", "force_sync", "Sync"),
         Binding("c", "create_task", "Create", show=True),
+        Binding("n", "switch_namespace", "Namespace", show=True),
         Binding("escape", "cancel_input", "Cancel", show=False),
     ]
 
     def __init__(
         self,
         *,
+        runtime: RuntimePaths | None = None,
+        workspace_base_dir: Path | None = None,
         db_path: Path | None = None,
         config: AgendumConfig | None = None,
     ) -> None:
         super().__init__()
-        self._db_path = db_path or DB_PATH
+        self._runtime = runtime or (
+            runtime_paths(db_path.parent) if db_path is not None else default_runtime_paths()
+        )
+        if db_path is not None:
+            self._runtime = RuntimePaths(
+                workspace_root=self._runtime.workspace_root,
+                config_path=self._runtime.config_path,
+                db_path=db_path,
+                gh_config_dir=self._runtime.gh_config_dir,
+            )
+        self._workspace_base_dir = workspace_base_dir or runtime_base_dir(self._runtime)
+        self._db_path = self._runtime.db_path
+        set_gh_config_dir(self._runtime.gh_config_dir)
         self._config = config  # resolved in on_mount if None
         self._task_rows: list[dict | None] = []  # None = section header
         self._last_sync: datetime | None = None
@@ -146,10 +172,25 @@ class AgendumApp(App):
         self._suspended = False
         self._wake_retry_count: int = 0
         self._title_width_chars: int = 10
+        self._input_mode: Literal["create", "namespace"] | None = None
+        self._sync_timer: Timer | None = None
+        self._spinner_timer: Timer | None = None
+        self._status_timer: Timer | None = None
+        self._sync_context_id = 0
 
     @property
     def db_path(self) -> Path:
         return self._db_path
+
+    @property
+    def runtime(self) -> RuntimePaths:
+        return self._runtime
+
+    @property
+    def current_namespace(self) -> str | None:
+        if self._config and self._config.orgs:
+            return self._config.orgs[0]
+        return None
 
     # ── compose ──────────────────────────────────────────────────────
 
@@ -255,7 +296,7 @@ class AgendumApp(App):
 
     async def on_mount(self) -> None:
         if self._config is None:
-            self._config = ensure_config()
+            self._config = ensure_workspace_config(self._runtime)
 
         init_db(self._db_path)
 
@@ -273,9 +314,9 @@ class AgendumApp(App):
         self._enable_focus_reporting()
         # Run initial sync immediately, then on interval
         self._start_sync()
-        self.set_interval(self._config.sync_interval, self._start_sync)
-        self.set_interval(0.25, self._tick_initial_sync_spinner)
-        self.set_interval(10, self._update_status_bar)
+        self._sync_timer = self.set_interval(self._config.sync_interval, self._start_sync)
+        self._spinner_timer = self.set_interval(0.25, self._tick_initial_sync_spinner)
+        self._status_timer = self.set_interval(10, self._update_status_bar)
 
     def on_resize(self, event: events.Resize) -> None:
         """Recompute title column width when terminal is resized."""
@@ -379,8 +420,10 @@ class AgendumApp(App):
         total = len(tasks)
         unseen_str = f" — {unseen} new" if unseen else ""
         sync_status = self._format_sync_status()
+        namespace = self.current_namespace
+        namespace_str = f" [{namespace}]" if namespace else ""
         self.query_one("#status-bar", Static).update(
-            f"agendum — {sync_status} — {total} tasks{unseen_str}"
+            f"agendum{namespace_str} — {sync_status} — {total} tasks{unseen_str}"
         )
 
     def _format_sync_status(self) -> str:
@@ -416,19 +459,45 @@ class AgendumApp(App):
     # ── input toggle ────────────────────────────────────────────────
 
     def action_create_task(self) -> None:
-        """Show the create-input and focus it."""
-        inp = self.query_one("#create-input", Input)
-        inp.add_class("visible")
-        inp.value = ""
-        inp.focus()
+        """Show the command input for task creation."""
+        self._show_input(
+            mode="create",
+            placeholder="type to create a new task…",
+            value="",
+        )
         self.notify("Type a task title, Enter to save, Escape to cancel", timeout=3)
+
+    def action_switch_namespace(self) -> None:
+        """Show the command input for namespace switching."""
+        self._show_input(
+            mode="namespace",
+            placeholder="GitHub namespace to switch into…",
+            value=self.current_namespace or "",
+        )
+        self.notify("Type a GitHub namespace, then Enter to re-auth", timeout=3)
 
     def action_cancel_input(self) -> None:
         """Hide the create-input and return focus to the table."""
+        self._input_mode = None
         inp = self.query_one("#create-input", Input)
         inp.remove_class("visible")
         inp.clear()
+        inp.placeholder = "type to create a new task…"
         self.query_one(DataTable).focus()
+
+    def _show_input(
+        self,
+        *,
+        mode: Literal["create", "namespace"],
+        placeholder: str,
+        value: str,
+    ) -> None:
+        self._input_mode = mode
+        inp = self.query_one("#create-input", Input)
+        inp.placeholder = placeholder
+        inp.add_class("visible")
+        inp.value = value
+        inp.focus()
 
     # ── row selection ────────────────────────────────────────────────
 
@@ -468,17 +537,62 @@ class AgendumApp(App):
     # ── task creation via input ──────────────────────────────────────
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
-        title = event.value.strip()
-        if not title:
+        value = event.value.strip()
+        if not value:
             self.action_cancel_input()
             return
-        add_task(self._db_path, title=title, source="manual", status="active")
-        event.input.clear()
-        event.input.remove_class("visible")
-        self.query_one(DataTable).focus()
+        mode = self._input_mode
+        self.action_cancel_input()
+        if mode == "namespace":
+            self._switch_namespace(value)
+            return
+
+        add_task(self._db_path, title=value, source="manual", status="active")
         self.refresh_table()
 
+    def _switch_namespace(self, namespace: str) -> None:
+        target_runtime = namespace_runtime_paths(namespace, self._workspace_base_dir)
+        with self.suspend():
+            authenticated = auth_login(target_runtime.gh_config_dir)
+        if not authenticated:
+            self._sync_error = "gh auth login failed"
+            self._update_status_bar()
+            return
+
+        config = ensure_workspace_config(
+            target_runtime,
+            namespace=namespace,
+            seed=self._config,
+        )
+        self._apply_runtime(target_runtime, config)
+        self.notify(f"Switched to {namespace}", timeout=3)
+
+    def _apply_runtime(self, runtime: RuntimePaths, config: AgendumConfig) -> None:
+        self._runtime = runtime
+        self._db_path = runtime.db_path
+        set_gh_config_dir(runtime.gh_config_dir)
+        self._config = config
+        init_db(self._db_path)
+        self._sync_context_id += 1
+        self._last_sync = None
+        self._sync_error = None
+        self._sync_in_progress = False
+        self._sync_spinner_frame = 0
+        self._last_sync_mono = time.monotonic()
+        self._last_sync_wall = time.time()
+        self._suspended = False
+        self._wake_retry_count = 0
+        if self._sync_timer is not None:
+            self._sync_timer.stop()
+            self._sync_timer = self.set_interval(self._config.sync_interval, self._start_sync)
+        self.refresh_table()
+        self._update_status_bar()
+        self._start_sync()
+
     # ── sync ─────────────────────────────────────────────────────────
+
+    def _sync_group(self) -> str:
+        return f"sync:{self._sync_context_id}"
 
     def _start_sync(self) -> None:
         """Kick off a sync in a background worker.
@@ -524,7 +638,11 @@ class AgendumApp(App):
         self._sync_in_progress = True
         self._sync_spinner_frame = 0
         self._update_status_bar()
-        self.run_worker(self._do_sync(), exclusive=True, group="sync")
+        self.run_worker(
+            self._do_sync(self._sync_context_id, self._db_path, self._config),
+            exclusive=True,
+            group=self._sync_group(),
+        )
 
     def _retry_sync_after_wake(self) -> None:
         """Attempt a sync as part of the wake retry sequence."""
@@ -533,7 +651,11 @@ class AgendumApp(App):
         self._sync_in_progress = True
         self._sync_spinner_frame = 0
         self._update_status_bar()
-        self.run_worker(self._do_sync(), exclusive=True, group="sync")
+        self.run_worker(
+            self._do_sync(self._sync_context_id, self._db_path, self._config),
+            exclusive=True,
+            group=self._sync_group(),
+        )
 
     def _handle_wake_retry_failure(self) -> None:
         """Schedule the next wake-retry attempt with exponential backoff."""
@@ -558,13 +680,19 @@ class AgendumApp(App):
         self._suspended = False
         self._wake_retry_count = 0
 
-    async def _do_sync(self) -> tuple[int, bool, str | None]:
+    async def _do_sync(
+        self,
+        sync_context_id: int,
+        db_path: Path,
+        config: AgendumConfig,
+    ) -> tuple[int, int, bool, str | None]:
         """Run sync in a worker thread — does not touch UI."""
-        return await run_sync(self._db_path, self._config)
+        changes, attention, error = await run_sync(db_path, config)
+        return sync_context_id, changes, attention, error
 
     def on_worker_state_changed(self, event: Worker.StateChanged) -> None:
         """Handle sync worker completion."""
-        if event.worker.group != "sync":
+        if event.worker.group != self._sync_group():
             return
         self._sync_in_progress = False
         if event.state != WorkerState.SUCCESS:
@@ -576,7 +704,7 @@ class AgendumApp(App):
                 else:
                     self._update_status_bar()
             return
-        changes, attention, error = event.worker.result
+        _, changes, attention, error = event.worker.result
         self._last_sync = datetime.now(timezone.utc)
         self._sync_error = error
         if self._suspended:

--- a/src/agendum/config.py
+++ b/src/agendum/config.py
@@ -1,4 +1,6 @@
+import json
 import os
+import re
 import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -6,6 +8,7 @@ from pathlib import Path
 CONFIG_DIR = Path.home() / ".agendum"
 CONFIG_PATH = CONFIG_DIR / "config.toml"
 DB_PATH = CONFIG_DIR / "agendum.db"
+WORKSPACES_DIRNAME = "workspaces"
 
 DEFAULT_CONFIG = """\
 [github]
@@ -40,23 +43,40 @@ class AgendumConfig:
 
 @dataclass(frozen=True)
 class RuntimePaths:
+    workspace_root: Path
     config_path: Path
     db_path: Path
+    gh_config_dir: Path
 
     @property
     def config_dir(self) -> Path:
-        return self.config_path.parent
+        return self.workspace_root
 
 
 def default_runtime_paths() -> RuntimePaths:
-    return RuntimePaths(config_path=CONFIG_PATH, db_path=DB_PATH)
+    return runtime_paths(CONFIG_DIR)
 
 
-def runtime_paths(config_dir: Path) -> RuntimePaths:
+def runtime_paths(workspace_root: Path) -> RuntimePaths:
     return RuntimePaths(
-        config_path=config_dir / "config.toml",
-        db_path=config_dir / "agendum.db",
+        workspace_root=workspace_root,
+        config_path=workspace_root / "config.toml",
+        db_path=workspace_root / "agendum.db",
+        gh_config_dir=workspace_root / "gh",
     )
+
+
+def runtime_base_dir(paths: RuntimePaths) -> Path:
+    workspace_root = paths.workspace_root
+    if workspace_root.parent.name == WORKSPACES_DIRNAME:
+        return workspace_root.parent.parent
+    return workspace_root
+
+
+def namespace_runtime_paths(namespace: str, base_root: Path | None = None) -> RuntimePaths:
+    base_root = base_root or CONFIG_DIR
+    namespace_dir = _namespace_directory_name(namespace)
+    return runtime_paths(base_root / WORKSPACES_DIRNAME / namespace_dir)
 
 
 def load_config(path: Path | None = None) -> AgendumConfig:
@@ -88,3 +108,79 @@ def ensure_config(path: Path | None = None) -> AgendumConfig:
         path.write_text(DEFAULT_CONFIG)
         os.chmod(path, 0o600)
     return load_config(path)
+
+
+def ensure_workspace_config(
+    paths: RuntimePaths,
+    *,
+    namespace: str | None = None,
+    seed: AgendumConfig | None = None,
+) -> AgendumConfig:
+    paths.workspace_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if paths.config_path.exists():
+        config = load_config(paths.config_path)
+        if config.orgs or config.repos or namespace is None:
+            return config
+        seed = config
+
+    config = _default_workspace_config(namespace=namespace, seed=seed)
+    write_config(paths.config_path, config)
+    return config
+
+
+def write_config(path: Path, config: AgendumConfig) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    path.write_text(render_config(config))
+    os.chmod(path, 0o600)
+
+
+def render_config(config: AgendumConfig) -> str:
+    return "\n".join(
+        [
+            "[github]",
+            "# GitHub org(s) to scan",
+            f"orgs = {json.dumps(config.orgs)}",
+            "",
+            '# Explicit repo whitelist ("owner/repo" format).',
+            "# If set, only these repos are synced — org-wide discovery is skipped.",
+            f"repos = {json.dumps(config.repos)}",
+            "",
+            '# Repos to exclude (optional, "owner/repo" format)',
+            f"exclude_repos = {json.dumps(config.exclude_repos)}",
+            "",
+            "[sync]",
+            "# Poll interval in seconds",
+            f"interval = {config.sync_interval}",
+            "",
+            "[display]",
+            "# Seconds after focus before marking items seen",
+            f"seen_delay = {config.seen_delay}",
+            "",
+        ]
+    )
+
+
+def _default_workspace_config(
+    *,
+    namespace: str | None,
+    seed: AgendumConfig | None,
+) -> AgendumConfig:
+    seed = seed or AgendumConfig()
+    if namespace is None:
+        return seed
+    return AgendumConfig(
+        orgs=[namespace],
+        repos=[],
+        exclude_repos=[],
+        sync_interval=seed.sync_interval,
+        seen_delay=seed.seen_delay,
+    )
+
+
+def _namespace_directory_name(namespace: str) -> str:
+    normalized = namespace.strip().lower()
+    normalized = re.sub(r"[^a-z0-9._-]+", "-", normalized)
+    normalized = normalized.strip(".-")
+    if not normalized:
+        raise ValueError("namespace must not be empty")
+    return normalized

--- a/src/agendum/config.py
+++ b/src/agendum/config.py
@@ -182,5 +182,5 @@ def _namespace_directory_name(namespace: str) -> str:
     normalized = re.sub(r"[^a-z0-9._-]+", "-", normalized)
     normalized = normalized.strip(".-")
     if not normalized:
-        raise ValueError("namespace must not be empty")
+        raise ValueError("namespace must include at least one letter or number")
     return normalized

--- a/src/agendum/config.py
+++ b/src/agendum/config.py
@@ -9,6 +9,7 @@ CONFIG_DIR = Path.home() / ".agendum"
 CONFIG_PATH = CONFIG_DIR / "config.toml"
 DB_PATH = CONFIG_DIR / "agendum.db"
 WORKSPACES_DIRNAME = "workspaces"
+_GITHUB_OWNER_RE = re.compile(r"^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$")
 
 DEFAULT_CONFIG = """\
 [github]
@@ -73,10 +74,38 @@ def runtime_base_dir(paths: RuntimePaths) -> Path:
     return workspace_root
 
 
-def namespace_runtime_paths(namespace: str, base_root: Path | None = None) -> RuntimePaths:
+def workspace_runtime_paths(
+    namespace: str | None,
+    base_root: Path | None = None,
+) -> RuntimePaths:
     base_root = base_root or CONFIG_DIR
-    namespace_dir = _namespace_directory_name(namespace)
-    return runtime_paths(base_root / WORKSPACES_DIRNAME / namespace_dir)
+    normalized = normalize_namespace(namespace)
+    if normalized is None:
+        return runtime_paths(base_root)
+    return runtime_paths(base_root / WORKSPACES_DIRNAME / _namespace_directory_name(normalized))
+
+
+def namespace_runtime_paths(namespace: str, base_root: Path | None = None) -> RuntimePaths:
+    normalized = normalize_namespace(namespace)
+    if normalized is None:
+        raise ValueError("enter at least one letter or number")
+    return workspace_runtime_paths(normalized, base_root)
+
+
+def normalize_namespace(namespace: str | None) -> str | None:
+    if namespace is None:
+        return None
+
+    normalized = namespace.strip()
+    if not normalized:
+        return None
+    if "/" in normalized:
+        raise ValueError("enter a GitHub owner name, not owner/repo")
+    if not re.search(r"[A-Za-z0-9]", normalized):
+        raise ValueError("enter at least one letter or number")
+    if "--" in normalized or not _GITHUB_OWNER_RE.fullmatch(normalized):
+        raise ValueError("enter a valid GitHub owner name")
+    return normalized
 
 
 def load_config(path: Path | None = None) -> AgendumConfig:
@@ -178,9 +207,7 @@ def _default_workspace_config(
 
 
 def _namespace_directory_name(namespace: str) -> str:
-    normalized = namespace.strip().lower()
-    normalized = re.sub(r"[^a-z0-9._-]+", "-", normalized)
-    normalized = normalized.strip(".-")
-    if not normalized:
-        raise ValueError("namespace must include at least one letter or number")
-    return normalized
+    normalized = normalize_namespace(namespace)
+    if normalized is None:
+        raise ValueError("enter at least one letter or number")
+    return normalized.lower()

--- a/src/agendum/demo.py
+++ b/src/agendum/demo.py
@@ -292,7 +292,7 @@ def _launch_demo(workspace_root: Path) -> None:
     print(f"Demo workspace: {workspace.paths.config_dir}")
     print("Seeded demo data in a disposable temp database.")
     print("Quit the app with `q` to clean up the workspace.")
-    app = AgendumApp(db_path=workspace.paths.db_path, config=workspace.config)
+    app = AgendumApp(runtime=workspace.paths, config=workspace.config)
     app.run()
 
 

--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -3,16 +3,25 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
 import json
 import logging
 import os
+import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterator, cast
 
 log = logging.getLogger(__name__)
 _GH_CONFIG_DIR: Path | None = None
+_GH_CONFIG_DIR_UNSET = object()
+_GH_CONFIG_FILES = ("hosts.yml", "config.yml")
+_TASK_GH_CONFIG_DIR: ContextVar[Path | None | object] = ContextVar(
+    "agendum_task_gh_config_dir",
+    default=_GH_CONFIG_DIR_UNSET,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -191,8 +200,9 @@ def has_unacknowledged_review_feedback(
 async def _run_gh(*args: str) -> str:
     """Run a gh CLI command and return stdout."""
     env = os.environ.copy()
-    if _GH_CONFIG_DIR is not None:
-        env["GH_CONFIG_DIR"] = str(_GH_CONFIG_DIR)
+    gh_config_dir = get_gh_config_dir()
+    if gh_config_dir is not None:
+        env["GH_CONFIG_DIR"] = str(gh_config_dir)
     proc = await asyncio.create_subprocess_exec(
         "gh", *args,
         stdout=asyncio.subprocess.PIPE,
@@ -228,6 +238,49 @@ def set_gh_config_dir(gh_config_dir: Path | None) -> None:
     """Configure the gh subprocess environment for the active workspace."""
     global _GH_CONFIG_DIR
     _GH_CONFIG_DIR = gh_config_dir
+
+
+def default_gh_config_dir() -> Path:
+    """Return gh's default config directory for this environment."""
+    if gh_config_dir := os.environ.get("GH_CONFIG_DIR"):
+        return Path(gh_config_dir)
+    if xdg_config_home := os.environ.get("XDG_CONFIG_HOME"):
+        return Path(xdg_config_home) / "gh"
+    return Path.home() / ".config" / "gh"
+
+
+def seed_gh_config_dir(gh_config_dir: Path, source_dir: Path | None = None) -> None:
+    """Copy the user's existing gh auth/config into a workspace-local gh dir."""
+    gh_config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    source_dir = source_dir or default_gh_config_dir()
+    if source_dir == gh_config_dir:
+        return
+
+    for filename in _GH_CONFIG_FILES:
+        source_path = source_dir / filename
+        target_path = gh_config_dir / filename
+        if target_path.exists() or not source_path.exists():
+            continue
+        shutil.copy2(source_path, target_path)
+        os.chmod(target_path, 0o600)
+
+
+def get_gh_config_dir() -> Path | None:
+    """Return the effective gh config dir for the current task."""
+    gh_config_dir = _TASK_GH_CONFIG_DIR.get()
+    if gh_config_dir is _GH_CONFIG_DIR_UNSET:
+        return _GH_CONFIG_DIR
+    return cast(Path | None, gh_config_dir)
+
+
+@contextmanager
+def use_gh_config_dir(gh_config_dir: Path | None) -> Iterator[None]:
+    """Temporarily bind a gh config dir to the current async task tree."""
+    token = _TASK_GH_CONFIG_DIR.set(gh_config_dir)
+    try:
+        yield
+    finally:
+        _TASK_GH_CONFIG_DIR.reset(token)
 
 
 # ---------------------------------------------------------------------------

--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -299,19 +299,37 @@ def refresh_gh_config_dir(gh_config_dir: Path, source_dir: Path | None = None) -
         os.chmod(target_path, 0o600)
 
 
+def _recovery_source_dirs(
+    gh_config_dir: Path,
+    *,
+    source_dir: Path | None,
+) -> list[Path]:
+    """List distinct upstream gh config dirs in recovery preference order."""
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in (source_dir, default_gh_config_dir()):
+        if candidate is None or candidate == gh_config_dir or candidate in seen:
+            continue
+        candidates.append(candidate)
+        seen.add(candidate)
+    return candidates
+
+
 def recover_gh_auth(
     gh_config_dir: Path,
     *,
     source_dir: Path | None = None,
     interactive: bool = False,
+    force_refresh: bool = False,
 ) -> bool:
-    """Recover workspace-local gh auth from local state, default auth, or login."""
-    if auth_status(gh_config_dir):
+    """Recover or refresh workspace-local gh auth from upstream state or login."""
+    if not force_refresh and auth_status(gh_config_dir):
         return True
 
-    source_dir = source_dir or default_gh_config_dir()
-    if source_dir != gh_config_dir and auth_status(source_dir):
-        refresh_gh_config_dir(gh_config_dir, source_dir)
+    for candidate in _recovery_source_dirs(gh_config_dir, source_dir=source_dir):
+        if not auth_status(candidate):
+            continue
+        refresh_gh_config_dir(gh_config_dir, candidate)
         if auth_status(gh_config_dir):
             return True
 

--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 log = logging.getLogger(__name__)
+_GH_CONFIG_DIR: Path | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -187,10 +190,14 @@ def has_unacknowledged_review_feedback(
 
 async def _run_gh(*args: str) -> str:
     """Run a gh CLI command and return stdout."""
+    env = os.environ.copy()
+    if _GH_CONFIG_DIR is not None:
+        env["GH_CONFIG_DIR"] = str(_GH_CONFIG_DIR)
     proc = await asyncio.create_subprocess_exec(
         "gh", *args,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
+        env=env,
     )
     stdout, stderr = await proc.communicate()
     if proc.returncode != 0:
@@ -203,6 +210,24 @@ async def get_gh_username() -> str:
     """Get the authenticated GitHub username."""
     result = await _run_gh("api", "user", "--jq", ".login")
     return result.strip()
+
+
+def auth_login(gh_config_dir: Path) -> bool:
+    """Run an interactive gh auth login with an isolated config directory."""
+    gh_config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    env = os.environ.copy()
+    env["GH_CONFIG_DIR"] = str(gh_config_dir)
+    try:
+        result = subprocess.run(["gh", "auth", "login"], env=env, check=False)
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0
+
+
+def set_gh_config_dir(gh_config_dir: Path | None) -> None:
+    """Configure the gh subprocess environment for the active workspace."""
+    global _GH_CONFIG_DIR
+    _GH_CONFIG_DIR = gh_config_dir
 
 
 # ---------------------------------------------------------------------------

--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -222,6 +222,24 @@ async def get_gh_username() -> str:
     return result.strip()
 
 
+def auth_status(gh_config_dir: Path | None = None) -> bool:
+    """Return whether gh has a valid authenticated session for a config dir."""
+    env = os.environ.copy()
+    if gh_config_dir is not None:
+        env["GH_CONFIG_DIR"] = str(gh_config_dir)
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "status"],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+    except FileNotFoundError:
+        return False
+    return result.returncode == 0
+
+
 def auth_login(gh_config_dir: Path) -> bool:
     """Run an interactive gh auth login with an isolated config directory."""
     gh_config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -263,6 +281,43 @@ def seed_gh_config_dir(gh_config_dir: Path, source_dir: Path | None = None) -> N
             continue
         shutil.copy2(source_path, target_path)
         os.chmod(target_path, 0o600)
+
+
+def refresh_gh_config_dir(gh_config_dir: Path, source_dir: Path | None = None) -> None:
+    """Refresh workspace-local gh auth/config from another gh config directory."""
+    gh_config_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
+    source_dir = source_dir or default_gh_config_dir()
+    if source_dir == gh_config_dir:
+        return
+
+    for filename in _GH_CONFIG_FILES:
+        source_path = source_dir / filename
+        if not source_path.exists():
+            continue
+        target_path = gh_config_dir / filename
+        shutil.copy2(source_path, target_path)
+        os.chmod(target_path, 0o600)
+
+
+def recover_gh_auth(
+    gh_config_dir: Path,
+    *,
+    source_dir: Path | None = None,
+    interactive: bool = False,
+) -> bool:
+    """Recover workspace-local gh auth from local state, default auth, or login."""
+    if auth_status(gh_config_dir):
+        return True
+
+    source_dir = source_dir or default_gh_config_dir()
+    if source_dir != gh_config_dir and auth_status(source_dir):
+        refresh_gh_config_dir(gh_config_dir, source_dir)
+        if auth_status(gh_config_dir):
+            return True
+
+    if not interactive:
+        return False
+    return auth_login(gh_config_dir)
 
 
 def get_gh_config_dir() -> Path | None:

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -253,6 +253,10 @@ async def _run_sync_once(
     await asyncio.gather(*(fetch_one_repo(r) for r in repos))
 
     review_prs, review_fetch_ok = await gh.discover_review_prs(config.orgs, gh_user)
+    if config.repos and not config.orgs:
+        # Repo-only workspaces do not currently have repo-scoped review discovery,
+        # so review cleanup cannot be treated as complete.
+        review_fetch_ok = False
     for pr_info in review_prs:
         repo_info = pr_info.get("repository", {})
         repo_full = repo_info.get("nameWithOwner", "")

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -102,6 +102,21 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
         log.warning("No orgs or repos configured — skipping sync")
         return 0, False, None
 
+    with gh.use_gh_config_dir(_workspace_gh_config_dir(db_path)):
+        return await _run_sync_once(db_path, config)
+
+
+def _workspace_gh_config_dir(db_path: Path) -> Path:
+    """Map a workspace DB path to its colocated gh auth/config directory."""
+    return db_path.parent / "gh"
+
+
+async def _run_sync_once(
+    db_path: Path,
+    config: AgendumConfig,
+) -> tuple[int, bool, str | None]:
+    """Execute a full sync cycle with the gh workspace already bound."""
+
     gh_user = await gh.get_gh_username()
     if not gh_user:
         log.error("Could not determine GitHub username")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -124,6 +124,38 @@ async def test_table_width_stays_within_viewport(tmp_db) -> None:
         await pilot.press("q")
 
 
+def test_stale_seen_delay_callback_is_ignored_after_workspace_switch(tmp_path) -> None:
+    from agendum.db import add_task, get_active_tasks, init_db, update_task
+
+    original_db = tmp_path / "original.db"
+    switched_db = tmp_path / "switched.db"
+    init_db(original_db)
+    init_db(switched_db)
+
+    original_task = add_task(original_db, title="Original", source="manual", status="active")
+    switched_task = add_task(switched_db, title="Switched", source="manual", status="active")
+    update_task(original_db, original_task, seen=0)
+    update_task(switched_db, switched_task, seen=0)
+
+    app = AgendumApp(
+        db_path=original_db,
+        config=AgendumConfig(orgs=[], sync_interval=9999, seen_delay=3),
+    )
+    app._app_focused = True
+
+    timer_callbacks: list[object] = []
+    app.set_timer = lambda delay, cb: timer_callbacks.append(cb) or SimpleNamespace(stop=lambda: None)  # type: ignore[assignment]
+
+    app.on_app_focus()
+    app._sync_context_id += 1
+    app._db_path = switched_db
+
+    timer_callbacks[0]()
+
+    assert get_active_tasks(original_db)[0]["seen"] == 0
+    assert get_active_tasks(switched_db)[0]["seen"] == 0
+
+
 # ── sleep/wake detection ─────────────────────────────────────────
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -11,6 +11,14 @@ from agendum.app import AgendumApp
 from agendum.config import AgendumConfig
 
 
+def _capture_worker_call(calls: list):
+    def fake_run_worker(coro, *args, **kwargs):
+        coro.close()
+        calls.append((args, kwargs))
+
+    return fake_run_worker
+
+
 @pytest.mark.asyncio
 async def test_app_starts_and_quits(tmp_db) -> None:
     from agendum.db import init_db
@@ -144,7 +152,7 @@ def test_sleep_detected_via_wall_vs_monotonic_drift(tmp_db) -> None:
     app._last_sync_wall = now_wall - 300
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     app._start_sync()
@@ -166,7 +174,7 @@ def test_no_sleep_detected_on_normal_interval(tmp_db) -> None:
     app._last_sync_wall = now_wall - 60
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     app._start_sync()
@@ -189,7 +197,7 @@ def test_first_sync_not_detected_as_sleep(tmp_db) -> None:
     app._last_sync_wall = now_wall - 600
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     app._start_sync()
@@ -209,7 +217,7 @@ def test_wake_retry_attempts_sync_immediately(tmp_db) -> None:
     app._wake_retry_count = 0
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     app._retry_sync_after_wake()
@@ -288,7 +296,7 @@ def test_start_sync_skipped_while_suspended(tmp_db) -> None:
     app._last_sync = datetime.now(timezone.utc)
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     app._start_sync()
@@ -302,7 +310,7 @@ def test_retry_sync_skipped_while_sync_in_progress(tmp_db) -> None:
     app._sync_in_progress = True
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     app._retry_sync_after_wake()
@@ -320,7 +328,7 @@ def test_force_sync_clears_suspended_state(tmp_db) -> None:
     app._last_sync_wall = time.time()
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     app.action_force_sync()
@@ -336,7 +344,7 @@ def test_stale_retry_timer_is_noop_after_force_sync(tmp_db) -> None:
     app._wake_retry_count = 0
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     # Simulate an orphaned backoff timer firing after suspended was cleared
@@ -370,7 +378,7 @@ def test_wake_retry_gives_up_after_max_retries(tmp_db) -> None:
 # ── on_worker_state_changed integration ──────────────────────────
 
 
-def _make_worker_event(state: WorkerState, group: str = "sync", error: BaseException | None = None, result=None):
+def _make_worker_event(state: WorkerState, group: str = "sync:0", error: BaseException | None = None, result=None):
     worker = MagicMock(spec=Worker)
     worker.group = group
     worker.error = error
@@ -409,7 +417,7 @@ def test_worker_success_while_suspended_clears_suspended(tmp_db) -> None:
     app.refresh_table = lambda: None  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
-    event = _make_worker_event(WorkerState.SUCCESS, result=(0, False, None))
+    event = _make_worker_event(WorkerState.SUCCESS, result=(0, 0, False, None))
     app.on_worker_state_changed(event)
 
     assert app._sync_in_progress is False
@@ -442,7 +450,7 @@ def test_start_sync_skipped_while_sync_in_progress(tmp_db) -> None:
     app._last_sync_wall = time.time()
 
     worker_calls: list = []
-    app.run_worker = lambda *a, **kw: worker_calls.append(1)  # type: ignore[assignment]
+    app.run_worker = _capture_worker_call(worker_calls)  # type: ignore[assignment]
     app._update_status_bar = lambda: None  # type: ignore[assignment]
 
     app._start_sync()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,7 @@ from textual.worker import Worker, WorkerState
 from textual.widgets import DataTable
 
 from agendum.app import AgendumApp
-from agendum.config import AgendumConfig
+from agendum.config import AgendumConfig, namespace_runtime_paths, runtime_paths
 
 
 def _capture_worker_call(calls: list):
@@ -154,6 +154,40 @@ def test_stale_seen_delay_callback_is_ignored_after_workspace_switch(tmp_path) -
 
     assert get_active_tasks(original_db)[0]["seen"] == 0
     assert get_active_tasks(switched_db)[0]["seen"] == 0
+
+
+def test_apply_runtime_rearms_seen_delay_when_app_is_focused(tmp_path) -> None:
+    base_root = tmp_path / ".agendum"
+    current_runtime = runtime_paths(base_root)
+    target_runtime = namespace_runtime_paths("example-org", base_root)
+
+    from agendum.db import init_db
+
+    init_db(current_runtime.db_path)
+    init_db(target_runtime.db_path)
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(orgs=["base"], sync_interval=9999, seen_delay=3),
+    )
+    app._app_focused = True
+
+    stopped: list[bool] = []
+    schedule_calls: list[bool] = []
+    app._seen_timer = SimpleNamespace(stop=lambda: stopped.append(True))
+    app._schedule_mark_seen = lambda: schedule_calls.append(True)  # type: ignore[assignment]
+    app.refresh_table = lambda: None  # type: ignore[assignment]
+    app._update_status_bar = lambda: None  # type: ignore[assignment]
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    app._apply_runtime(
+        target_runtime,
+        AgendumConfig(orgs=["example-org"], sync_interval=9999, seen_delay=3),
+    )
+
+    assert stopped == [True]
+    assert schedule_calls == [True]
 
 
 # ── sleep/wake detection ─────────────────────────────────────────

--- a/tests/test_app_interaction.py
+++ b/tests/test_app_interaction.py
@@ -8,7 +8,13 @@ import pytest
 from textual.widgets import DataTable, Input
 
 from agendum.app import AgendumApp
-from agendum.config import AgendumConfig, load_config, namespace_runtime_paths, runtime_paths
+from agendum.config import (
+    AgendumConfig,
+    ensure_workspace_config,
+    load_config,
+    namespace_runtime_paths,
+    runtime_paths,
+)
 from agendum.db import add_task, get_active_tasks, init_db, update_task
 
 
@@ -230,6 +236,38 @@ async def test_switch_namespace_reauths_into_isolated_workspace(
         assert load_config(target_runtime.config_path).orgs == ["example-org"]
 
 
+async def test_switch_namespace_is_noop_for_current_workspace(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_root = tmp_path / ".agendum"
+    current_runtime = namespace_runtime_paths("example-org", base_root)
+    init_db(current_runtime.db_path)
+
+    auth_calls: list[Path] = []
+    monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
+    monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(orgs=["example-org"], sync_interval=9999, seen_delay=3),
+    )
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    async with app.run_test() as pilot:
+        original_sync_context_id = app._sync_context_id
+        await pilot.press("n")
+        await pilot.pause()
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert auth_calls == []
+        assert app._sync_context_id == original_sync_context_id
+        assert app.runtime == current_runtime
+        assert app.db_path == current_runtime.db_path
+
+
 async def test_switch_namespace_keeps_current_workspace_when_auth_fails(
     tmp_path: Path,
     monkeypatch,
@@ -260,6 +298,49 @@ async def test_switch_namespace_keeps_current_workspace_when_auth_fails(
         assert app.runtime == current_runtime
         assert not namespace_runtime_paths("example-org", base_root).config_path.exists()
         assert app._sync_error == "gh auth login failed"
+
+
+async def test_switch_namespace_blank_returns_to_base_workspace(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_root = tmp_path / ".agendum"
+    base_runtime = runtime_paths(base_root)
+    init_db(base_runtime.db_path)
+    ensure_workspace_config(
+        base_runtime,
+        seed=AgendumConfig(orgs=["base-org"], sync_interval=9999, seen_delay=3),
+    )
+
+    current_runtime = namespace_runtime_paths("example-org", base_root)
+    init_db(current_runtime.db_path)
+
+    auth_calls: list[Path] = []
+    monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
+    monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(orgs=["example-org"], sync_interval=9999, seen_delay=3),
+    )
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    async with app.run_test() as pilot:
+        await pilot.press("n")
+        await pilot.pause()
+
+        inp = app.query_one("#create-input", Input)
+        inp.value = ""
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert auth_calls == []
+        assert app.runtime == base_runtime
+        assert app.db_path == base_runtime.db_path
+        assert app.current_namespace is None
+        assert load_config(base_runtime.config_path).orgs == ["base-org"]
 
 
 async def test_switch_namespace_rejects_invalid_namespace_without_changing_workspace(
@@ -298,3 +379,41 @@ async def test_switch_namespace_rejects_invalid_namespace_without_changing_works
         assert not (base_root / "workspaces").exists()
         assert notifications[-1].severity == "error"
         assert notifications[-1].message == "Invalid namespace: enter at least one letter or number."
+
+
+async def test_switch_namespace_rejects_owner_repo_input_without_changing_workspace(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_root = tmp_path / ".agendum"
+    current_runtime = runtime_paths(base_root)
+    init_db(current_runtime.db_path)
+
+    auth_calls: list[Path] = []
+    monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
+    monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(orgs=["current"], sync_interval=9999, seen_delay=3),
+    )
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    async with app.run_test(notifications=True) as pilot:
+        await pilot.press("n")
+        await pilot.pause()
+
+        inp = app.query_one("#create-input", Input)
+        inp.value = "owner/repo"
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        notifications = list(app._notifications)
+        assert auth_calls == []
+        assert app.runtime == current_runtime
+        assert app.db_path == current_runtime.db_path
+        assert not (base_root / "workspaces").exists()
+        assert notifications[-1].severity == "error"
+        assert notifications[-1].message == "Invalid namespace: enter a GitHub owner name, not owner/repo."

--- a/tests/test_app_interaction.py
+++ b/tests/test_app_interaction.py
@@ -1,13 +1,14 @@
 """Tests for AgendumApp user interaction — navigation, actions, input, sync."""
 
+from contextlib import nullcontext
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from textual.widgets import DataTable
+from textual.widgets import DataTable, Input
 
 from agendum.app import AgendumApp
-from agendum.config import AgendumConfig
+from agendum.config import AgendumConfig, load_config, namespace_runtime_paths, runtime_paths
 from agendum.db import add_task, get_active_tasks, init_db, update_task
 
 
@@ -190,3 +191,72 @@ def test_format_sync_error_empty_message(tmp_db: Path) -> None:
 def test_format_sync_error_none(tmp_db: Path) -> None:
     app = _app(tmp_db)
     assert app._format_sync_error(None) == "unknown sync error"
+
+
+async def test_switch_namespace_reauths_into_isolated_workspace(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_root = tmp_path / ".agendum"
+    current_runtime = runtime_paths(base_root)
+    init_db(current_runtime.db_path)
+
+    auth_calls: list[Path] = []
+    monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
+    monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(orgs=["current"], sync_interval=9999, seen_delay=3),
+    )
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    async with app.run_test() as pilot:
+        await pilot.press("n")
+        await pilot.pause()
+
+        inp = app.query_one("#create-input", Input)
+        assert inp.has_class("visible")
+        inp.value = "example-org"
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        target_runtime = namespace_runtime_paths("example-org", base_root)
+        assert auth_calls == [target_runtime.gh_config_dir]
+        assert app.runtime == target_runtime
+        assert app.db_path == target_runtime.db_path
+        assert load_config(target_runtime.config_path).orgs == ["example-org"]
+
+
+async def test_switch_namespace_keeps_current_workspace_when_auth_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_root = tmp_path / ".agendum"
+    current_runtime = runtime_paths(base_root)
+    init_db(current_runtime.db_path)
+
+    monkeypatch.setattr("agendum.app.auth_login", lambda _gh_dir: False)
+    monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(orgs=["current"], sync_interval=9999, seen_delay=3),
+    )
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    async with app.run_test() as pilot:
+        await pilot.press("n")
+        await pilot.pause()
+        inp = app.query_one("#create-input", Input)
+        inp.value = "example-org"
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert app.runtime == current_runtime
+        assert not namespace_runtime_paths("example-org", base_root).config_path.exists()
+        assert app._sync_error == "gh auth login failed"

--- a/tests/test_app_interaction.py
+++ b/tests/test_app_interaction.py
@@ -207,11 +207,11 @@ async def test_switch_namespace_reauths_into_isolated_workspace(
     current_runtime = runtime_paths(base_root)
     init_db(current_runtime.db_path)
 
-    recover_calls: list[Path] = []
+    recover_calls: list[tuple[Path, Path | None]] = []
     auth_calls: list[Path] = []
     monkeypatch.setattr(
         "agendum.app.recover_gh_auth",
-        lambda gh_dir: recover_calls.append(gh_dir) or False,
+        lambda gh_dir, source_dir=None: recover_calls.append((gh_dir, source_dir)) or False,
     )
     monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
     monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
@@ -235,7 +235,7 @@ async def test_switch_namespace_reauths_into_isolated_workspace(
         await pilot.pause()
 
         target_runtime = namespace_runtime_paths("example-org", base_root)
-        assert recover_calls == [target_runtime.gh_config_dir]
+        assert recover_calls == [(target_runtime.gh_config_dir, current_runtime.gh_config_dir)]
         assert auth_calls == [target_runtime.gh_config_dir]
         assert app.runtime == target_runtime
         assert app.db_path == target_runtime.db_path
@@ -250,11 +250,11 @@ async def test_switch_namespace_reuses_existing_workspace_auth_without_prompt(
     current_runtime = runtime_paths(base_root)
     init_db(current_runtime.db_path)
 
-    recover_calls: list[Path] = []
+    recover_calls: list[tuple[Path, Path | None]] = []
     auth_calls: list[Path] = []
     monkeypatch.setattr(
         "agendum.app.recover_gh_auth",
-        lambda gh_dir: recover_calls.append(gh_dir) or True,
+        lambda gh_dir, source_dir=None: recover_calls.append((gh_dir, source_dir)) or True,
     )
     monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
     monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
@@ -277,7 +277,7 @@ async def test_switch_namespace_reuses_existing_workspace_auth_without_prompt(
         await pilot.pause()
 
         target_runtime = namespace_runtime_paths("example-org", base_root)
-        assert recover_calls == [target_runtime.gh_config_dir]
+        assert recover_calls == [(target_runtime.gh_config_dir, current_runtime.gh_config_dir)]
         assert auth_calls == []
         assert app.runtime == target_runtime
         assert app.db_path == target_runtime.db_path
@@ -334,7 +334,7 @@ async def test_repo_only_namespace_keeps_identity_and_noops_on_resubmit(
     )
 
     auth_calls: list[Path] = []
-    monkeypatch.setattr("agendum.app.recover_gh_auth", lambda _gh_dir: True)
+    monkeypatch.setattr("agendum.app.recover_gh_auth", lambda _gh_dir, source_dir=None: True)
     monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
     monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
 
@@ -375,7 +375,11 @@ async def test_switch_namespace_keeps_current_workspace_when_auth_fails(
     current_runtime = runtime_paths(base_root)
     init_db(current_runtime.db_path)
 
-    monkeypatch.setattr("agendum.app.recover_gh_auth", lambda _gh_dir: False)
+    recover_calls: list[tuple[Path, Path | None]] = []
+    monkeypatch.setattr(
+        "agendum.app.recover_gh_auth",
+        lambda gh_dir, source_dir=None: recover_calls.append((gh_dir, source_dir)) or False,
+    )
     monkeypatch.setattr("agendum.app.auth_login", lambda _gh_dir: False)
     monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
 
@@ -396,6 +400,10 @@ async def test_switch_namespace_keeps_current_workspace_when_auth_fails(
         await pilot.pause()
 
         assert app.runtime == current_runtime
+        assert recover_calls == [(
+            namespace_runtime_paths("example-org", base_root).gh_config_dir,
+            current_runtime.gh_config_dir,
+        )]
         assert not namespace_runtime_paths("example-org", base_root).config_path.exists()
         assert app._sync_error == "gh auth login failed"
 
@@ -415,7 +423,12 @@ async def test_switch_namespace_blank_returns_to_base_workspace(
     current_runtime = namespace_runtime_paths("example-org", base_root)
     init_db(current_runtime.db_path)
 
+    recover_calls: list[tuple[Path, Path | None]] = []
     auth_calls: list[Path] = []
+    monkeypatch.setattr(
+        "agendum.app.recover_gh_auth",
+        lambda gh_dir, source_dir=None: recover_calls.append((gh_dir, source_dir)) or True,
+    )
     monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
     monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
 
@@ -437,6 +450,7 @@ async def test_switch_namespace_blank_returns_to_base_workspace(
         await pilot.pause()
 
         assert auth_calls == []
+        assert recover_calls == [(base_runtime.gh_config_dir, current_runtime.gh_config_dir)]
         assert app.runtime == base_runtime
         assert app.db_path == base_runtime.db_path
         assert app.current_namespace is None

--- a/tests/test_app_interaction.py
+++ b/tests/test_app_interaction.py
@@ -260,3 +260,41 @@ async def test_switch_namespace_keeps_current_workspace_when_auth_fails(
         assert app.runtime == current_runtime
         assert not namespace_runtime_paths("example-org", base_root).config_path.exists()
         assert app._sync_error == "gh auth login failed"
+
+
+async def test_switch_namespace_rejects_invalid_namespace_without_changing_workspace(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_root = tmp_path / ".agendum"
+    current_runtime = runtime_paths(base_root)
+    init_db(current_runtime.db_path)
+
+    auth_calls: list[Path] = []
+    monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
+    monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(orgs=["current"], sync_interval=9999, seen_delay=3),
+    )
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    async with app.run_test(notifications=True) as pilot:
+        await pilot.press("n")
+        await pilot.pause()
+
+        inp = app.query_one("#create-input", Input)
+        inp.value = "!!!"
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        notifications = list(app._notifications)
+        assert auth_calls == []
+        assert app.runtime == current_runtime
+        assert app.db_path == current_runtime.db_path
+        assert not (base_root / "workspaces").exists()
+        assert notifications[-1].severity == "error"
+        assert notifications[-1].message == "Invalid namespace: enter at least one letter or number."

--- a/tests/test_app_interaction.py
+++ b/tests/test_app_interaction.py
@@ -207,7 +207,12 @@ async def test_switch_namespace_reauths_into_isolated_workspace(
     current_runtime = runtime_paths(base_root)
     init_db(current_runtime.db_path)
 
+    recover_calls: list[Path] = []
     auth_calls: list[Path] = []
+    monkeypatch.setattr(
+        "agendum.app.recover_gh_auth",
+        lambda gh_dir: recover_calls.append(gh_dir) or False,
+    )
     monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
     monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
 
@@ -230,10 +235,52 @@ async def test_switch_namespace_reauths_into_isolated_workspace(
         await pilot.pause()
 
         target_runtime = namespace_runtime_paths("example-org", base_root)
+        assert recover_calls == [target_runtime.gh_config_dir]
         assert auth_calls == [target_runtime.gh_config_dir]
         assert app.runtime == target_runtime
         assert app.db_path == target_runtime.db_path
         assert load_config(target_runtime.config_path).orgs == ["example-org"]
+
+
+async def test_switch_namespace_reuses_existing_workspace_auth_without_prompt(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_root = tmp_path / ".agendum"
+    current_runtime = runtime_paths(base_root)
+    init_db(current_runtime.db_path)
+
+    recover_calls: list[Path] = []
+    auth_calls: list[Path] = []
+    monkeypatch.setattr(
+        "agendum.app.recover_gh_auth",
+        lambda gh_dir: recover_calls.append(gh_dir) or True,
+    )
+    monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
+    monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(orgs=["current"], sync_interval=9999, seen_delay=3),
+    )
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    async with app.run_test() as pilot:
+        await pilot.press("n")
+        await pilot.pause()
+
+        inp = app.query_one("#create-input", Input)
+        inp.value = "example-org"
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        target_runtime = namespace_runtime_paths("example-org", base_root)
+        assert recover_calls == [target_runtime.gh_config_dir]
+        assert auth_calls == []
+        assert app.runtime == target_runtime
+        assert app.db_path == target_runtime.db_path
 
 
 async def test_switch_namespace_is_noop_for_current_workspace(
@@ -268,6 +315,58 @@ async def test_switch_namespace_is_noop_for_current_workspace(
         assert app.db_path == current_runtime.db_path
 
 
+async def test_repo_only_namespace_keeps_identity_and_noops_on_resubmit(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    base_root = tmp_path / ".agendum"
+    current_runtime = namespace_runtime_paths("example-org", base_root)
+    init_db(current_runtime.db_path)
+    ensure_workspace_config(
+        current_runtime,
+        seed=AgendumConfig(
+            orgs=[],
+            repos=["example-org/repo"],
+            exclude_repos=[],
+            sync_interval=9999,
+            seen_delay=3,
+        ),
+    )
+
+    auth_calls: list[Path] = []
+    monkeypatch.setattr("agendum.app.recover_gh_auth", lambda _gh_dir: True)
+    monkeypatch.setattr("agendum.app.auth_login", lambda gh_dir: auth_calls.append(gh_dir) or True)
+    monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
+
+    app = AgendumApp(
+        runtime=current_runtime,
+        workspace_base_dir=base_root,
+        config=AgendumConfig(
+            orgs=[],
+            repos=["example-org/repo"],
+            exclude_repos=[],
+            sync_interval=9999,
+            seen_delay=3,
+        ),
+    )
+    app._start_sync = lambda: None  # type: ignore[assignment]
+
+    async with app.run_test() as pilot:
+        assert app.current_namespace == "example-org"
+        await pilot.press("n")
+        await pilot.pause()
+
+        inp = app.query_one("#create-input", Input)
+        assert inp.value == "example-org"
+
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert auth_calls == []
+        assert app.runtime == current_runtime
+        assert app.current_namespace == "example-org"
+
+
 async def test_switch_namespace_keeps_current_workspace_when_auth_fails(
     tmp_path: Path,
     monkeypatch,
@@ -276,6 +375,7 @@ async def test_switch_namespace_keeps_current_workspace_when_auth_fails(
     current_runtime = runtime_paths(base_root)
     init_db(current_runtime.db_path)
 
+    monkeypatch.setattr("agendum.app.recover_gh_auth", lambda _gh_dir: False)
     monkeypatch.setattr("agendum.app.auth_login", lambda _gh_dir: False)
     monkeypatch.setattr(AgendumApp, "suspend", lambda self: nullcontext())
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,13 @@
 from pathlib import Path
-from agendum.config import load_config, AgendumConfig, DEFAULT_CONFIG
+from agendum.config import (
+    DEFAULT_CONFIG,
+    AgendumConfig,
+    ensure_workspace_config,
+    load_config,
+    namespace_runtime_paths,
+    runtime_base_dir,
+    runtime_paths,
+)
 
 
 def test_default_config_when_no_file(tmp_path: Path) -> None:
@@ -48,3 +56,35 @@ orgs = ["example-org"]
 def test_default_config_string() -> None:
     assert "[github]" in DEFAULT_CONFIG
     assert "orgs" in DEFAULT_CONFIG
+
+
+def test_runtime_paths_include_workspace_and_gh_dir(tmp_path: Path) -> None:
+    paths = runtime_paths(tmp_path / ".agendum")
+
+    assert paths.workspace_root == tmp_path / ".agendum"
+    assert paths.config_path == tmp_path / ".agendum" / "config.toml"
+    assert paths.db_path == tmp_path / ".agendum" / "agendum.db"
+    assert paths.gh_config_dir == tmp_path / ".agendum" / "gh"
+
+
+def test_namespace_runtime_paths_are_nested_under_workspaces(tmp_path: Path) -> None:
+    paths = namespace_runtime_paths("Example-Org", tmp_path / ".agendum")
+
+    assert paths.workspace_root == tmp_path / ".agendum" / "workspaces" / "example-org"
+    assert runtime_base_dir(paths) == tmp_path / ".agendum"
+
+
+def test_ensure_workspace_config_seeds_namespace_and_timing(tmp_path: Path) -> None:
+    paths = namespace_runtime_paths("example-org", tmp_path / ".agendum")
+    config = ensure_workspace_config(
+        paths,
+        namespace="example-org",
+        seed=AgendumConfig(sync_interval=120, seen_delay=9),
+    )
+
+    assert config.orgs == ["example-org"]
+    assert config.repos == []
+    assert config.exclude_repos == []
+    assert config.sync_interval == 120
+    assert config.seen_delay == 9
+    assert load_config(paths.config_path).orgs == ["example-org"]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+
+import pytest
+
 from agendum.config import (
     DEFAULT_CONFIG,
     AgendumConfig,
@@ -72,6 +75,11 @@ def test_namespace_runtime_paths_are_nested_under_workspaces(tmp_path: Path) -> 
 
     assert paths.workspace_root == tmp_path / ".agendum" / "workspaces" / "example-org"
     assert runtime_base_dir(paths) == tmp_path / ".agendum"
+
+
+def test_namespace_runtime_paths_rejects_normalized_empty_namespace(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="at least one letter or number"):
+        namespace_runtime_paths("!!!", tmp_path / ".agendum")
 
 
 def test_ensure_workspace_config_seeds_namespace_and_timing(tmp_path: Path) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,6 +10,7 @@ from agendum.config import (
     namespace_runtime_paths,
     runtime_base_dir,
     runtime_paths,
+    workspace_runtime_paths,
 )
 
 
@@ -77,9 +78,20 @@ def test_namespace_runtime_paths_are_nested_under_workspaces(tmp_path: Path) -> 
     assert runtime_base_dir(paths) == tmp_path / ".agendum"
 
 
+def test_workspace_runtime_paths_with_blank_namespace_returns_base_workspace(tmp_path: Path) -> None:
+    paths = workspace_runtime_paths("", tmp_path / ".agendum")
+
+    assert paths == runtime_paths(tmp_path / ".agendum")
+
+
 def test_namespace_runtime_paths_rejects_normalized_empty_namespace(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="at least one letter or number"):
         namespace_runtime_paths("!!!", tmp_path / ".agendum")
+
+
+def test_namespace_runtime_paths_reject_owner_repo_input(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="owner name, not owner/repo"):
+        namespace_runtime_paths("owner/repo", tmp_path / ".agendum")
 
 
 def test_ensure_workspace_config_seeds_namespace_and_timing(tmp_path: Path) -> None:

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -4,14 +4,18 @@ import pytest
 
 from agendum.gh import (
     auth_login,
+    default_gh_config_dir,
     derive_authored_pr_status,
     derive_review_pr_status,
     derive_issue_status,
     fetch_review_detail,
+    get_gh_config_dir,
     _run_gh,
     parse_author_first_name,
     extract_repo_short_name,
+    seed_gh_config_dir,
     set_gh_config_dir,
+    use_gh_config_dir,
 )
 
 
@@ -281,6 +285,42 @@ def test_auth_login_uses_isolated_gh_config_dir(tmp_path, monkeypatch) -> None:
     assert calls["check"] is False
 
 
+def test_default_gh_config_dir_prefers_xdg_env(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+
+    assert default_gh_config_dir() == tmp_path / "xdg" / "gh"
+
+
+def test_seed_gh_config_dir_copies_default_auth_files(tmp_path) -> None:
+    source_dir = tmp_path / "source-gh"
+    source_dir.mkdir()
+    (source_dir / "hosts.yml").write_text("github.com:\n  oauth_token: token\n")
+    (source_dir / "config.yml").write_text("git_protocol: ssh\n")
+
+    target_dir = tmp_path / "workspace-gh"
+    seed_gh_config_dir(target_dir, source_dir=source_dir)
+
+    assert (target_dir / "hosts.yml").read_text() == (source_dir / "hosts.yml").read_text()
+    assert (target_dir / "config.yml").read_text() == (source_dir / "config.yml").read_text()
+    assert (target_dir / "hosts.yml").stat().st_mode & 0o777 == 0o600
+    assert (target_dir / "config.yml").stat().st_mode & 0o777 == 0o600
+
+
+def test_seed_gh_config_dir_preserves_existing_workspace_auth(tmp_path) -> None:
+    source_dir = tmp_path / "source-gh"
+    source_dir.mkdir()
+    (source_dir / "hosts.yml").write_text("github.com:\n  oauth_token: old\n")
+
+    target_dir = tmp_path / "workspace-gh"
+    target_dir.mkdir()
+    (target_dir / "hosts.yml").write_text("github.com:\n  oauth_token: current\n")
+
+    seed_gh_config_dir(target_dir, source_dir=source_dir)
+
+    assert (target_dir / "hosts.yml").read_text() == "github.com:\n  oauth_token: current\n"
+
+
 @pytest.mark.asyncio
 async def test_run_gh_uses_active_workspace_config_dir(tmp_path, monkeypatch) -> None:
     calls = {}
@@ -307,6 +347,38 @@ async def test_run_gh_uses_active_workspace_config_dir(tmp_path, monkeypatch) ->
 
     assert calls["args"] == ("gh", "api", "user", "--jq", ".login")
     assert calls["kwargs"]["env"]["GH_CONFIG_DIR"] == str(gh_dir)
+
+
+@pytest.mark.asyncio
+async def test_run_gh_prefers_task_local_workspace_config_dir(tmp_path, monkeypatch) -> None:
+    calls = {}
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok\n", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr("agendum.gh.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+
+    global_dir = tmp_path / "global" / "gh"
+    task_dir = tmp_path / "task" / "gh"
+    set_gh_config_dir(global_dir)
+    try:
+        with use_gh_config_dir(task_dir):
+            assert get_gh_config_dir() == task_dir
+            assert await _run_gh("api", "user", "--jq", ".login") == "ok\n"
+        assert get_gh_config_dir() == global_dir
+    finally:
+        set_gh_config_dir(None)
+
+    assert calls["args"] == ("gh", "api", "user", "--jq", ".login")
+    assert calls["kwargs"]["env"]["GH_CONFIG_DIR"] == str(task_dir)
 
 
 def test_review_pr_reviewed() -> None:

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 from types import SimpleNamespace
 import pytest
 
@@ -406,6 +407,33 @@ def test_recover_gh_auth_refreshes_workspace_from_default_auth(tmp_path, monkeyp
     assert refresh_calls == [(gh_dir, source_dir)]
 
 
+def test_recover_gh_auth_prefers_current_workspace_auth_before_default(tmp_path, monkeypatch) -> None:
+    gh_dir = tmp_path / "target" / "gh"
+    source_dir = tmp_path / "current" / "gh"
+    default_dir = tmp_path / "default" / "gh"
+    status_by_dir = {
+        gh_dir: False,
+        source_dir: True,
+        default_dir: False,
+    }
+    refresh_calls: list[tuple[Path, Path | None]] = []
+
+    def fake_auth_status(path=None):
+        return status_by_dir.get(path, False)
+
+    def fake_refresh(target, source_dir=None):
+        refresh_calls.append((target, source_dir))
+        status_by_dir[target] = True
+
+    monkeypatch.setattr("agendum.gh.auth_status", fake_auth_status)
+    monkeypatch.setattr("agendum.gh.refresh_gh_config_dir", fake_refresh)
+    monkeypatch.setattr("agendum.gh.default_gh_config_dir", lambda: default_dir)
+    monkeypatch.setattr("agendum.gh.auth_login", lambda _target: pytest.fail("unexpected interactive login"))
+
+    assert recover_gh_auth(gh_dir, source_dir=source_dir) is True
+    assert refresh_calls == [(gh_dir, source_dir)]
+
+
 def test_recover_gh_auth_falls_back_to_interactive_login(tmp_path, monkeypatch) -> None:
     gh_dir = tmp_path / "workspace" / "gh"
     source_dir = tmp_path / "default" / "gh"
@@ -420,6 +448,37 @@ def test_recover_gh_auth_falls_back_to_interactive_login(tmp_path, monkeypatch) 
 
     assert recover_gh_auth(gh_dir, source_dir=source_dir, interactive=True) is True
     assert login_calls == [gh_dir]
+
+
+def test_recover_gh_auth_force_refreshes_even_when_workspace_auth_exists(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    gh_dir = tmp_path / "workspace" / "gh"
+    source_dir = tmp_path / "current" / "gh"
+    status_by_dir = {
+        gh_dir: True,
+        source_dir: True,
+    }
+    refresh_calls: list[tuple[Path, Path | None]] = []
+
+    def fake_auth_status(path=None):
+        return status_by_dir.get(path, False)
+
+    def fake_refresh(target, source_dir=None):
+        refresh_calls.append((target, source_dir))
+
+    monkeypatch.setattr("agendum.gh.auth_status", fake_auth_status)
+    monkeypatch.setattr("agendum.gh.refresh_gh_config_dir", fake_refresh)
+    monkeypatch.setattr("agendum.gh.auth_login", lambda _target: pytest.fail("unexpected interactive login"))
+
+    assert recover_gh_auth(
+        gh_dir,
+        source_dir=source_dir,
+        interactive=True,
+        force_refresh=True,
+    ) is True
+    assert refresh_calls == [(gh_dir, source_dir)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -1,13 +1,17 @@
 import json
+from types import SimpleNamespace
 import pytest
 
 from agendum.gh import (
+    auth_login,
     derive_authored_pr_status,
     derive_review_pr_status,
     derive_issue_status,
     fetch_review_detail,
+    _run_gh,
     parse_author_first_name,
     extract_repo_short_name,
+    set_gh_config_dir,
 )
 
 
@@ -256,6 +260,53 @@ def test_authored_pr_review_received_clears_after_push_without_feedback_threads(
 
 def test_review_pr_requested() -> None:
     assert derive_review_pr_status(user_has_reviewed=False, new_commits_since_review=False) == "review requested"
+
+
+def test_auth_login_uses_isolated_gh_config_dir(tmp_path, monkeypatch) -> None:
+    calls = {}
+
+    def fake_run(args, *, env, check):
+        calls["args"] = args
+        calls["env"] = env
+        calls["check"] = check
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("agendum.gh.subprocess.run", fake_run)
+
+    gh_dir = tmp_path / "workspace" / "gh"
+    assert auth_login(gh_dir) is True
+    assert gh_dir.is_dir()
+    assert calls["args"] == ["gh", "auth", "login"]
+    assert calls["env"]["GH_CONFIG_DIR"] == str(gh_dir)
+    assert calls["check"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_gh_uses_active_workspace_config_dir(tmp_path, monkeypatch) -> None:
+    calls = {}
+
+    class FakeProcess:
+        returncode = 0
+
+        async def communicate(self):
+            return b"ok\n", b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return FakeProcess()
+
+    monkeypatch.setattr("agendum.gh.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+
+    gh_dir = tmp_path / "workspace" / "gh"
+    set_gh_config_dir(gh_dir)
+    try:
+        assert await _run_gh("api", "user", "--jq", ".login") == "ok\n"
+    finally:
+        set_gh_config_dir(None)
+
+    assert calls["args"] == ("gh", "api", "user", "--jq", ".login")
+    assert calls["kwargs"]["env"]["GH_CONFIG_DIR"] == str(gh_dir)
 
 
 def test_review_pr_reviewed() -> None:

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -3,7 +3,9 @@ from types import SimpleNamespace
 import pytest
 
 from agendum.gh import (
+    auth_status,
     auth_login,
+    recover_gh_auth,
     default_gh_config_dir,
     derive_authored_pr_status,
     derive_review_pr_status,
@@ -13,6 +15,7 @@ from agendum.gh import (
     _run_gh,
     parse_author_first_name,
     extract_repo_short_name,
+    refresh_gh_config_dir,
     seed_gh_config_dir,
     set_gh_config_dir,
     use_gh_config_dir,
@@ -285,6 +288,28 @@ def test_auth_login_uses_isolated_gh_config_dir(tmp_path, monkeypatch) -> None:
     assert calls["check"] is False
 
 
+def test_auth_status_uses_isolated_gh_config_dir(tmp_path, monkeypatch) -> None:
+    calls = {}
+
+    def fake_run(args, *, capture_output, text, env, check):
+        calls["args"] = args
+        calls["capture_output"] = capture_output
+        calls["text"] = text
+        calls["env"] = env
+        calls["check"] = check
+        return SimpleNamespace(returncode=0)
+
+    monkeypatch.setattr("agendum.gh.subprocess.run", fake_run)
+
+    gh_dir = tmp_path / "workspace" / "gh"
+    assert auth_status(gh_dir) is True
+    assert calls["args"] == ["gh", "auth", "status"]
+    assert calls["capture_output"] is True
+    assert calls["text"] is True
+    assert calls["env"]["GH_CONFIG_DIR"] == str(gh_dir)
+    assert calls["check"] is False
+
+
 def test_default_gh_config_dir_prefers_xdg_env(tmp_path, monkeypatch) -> None:
     monkeypatch.delenv("GH_CONFIG_DIR", raising=False)
     monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
@@ -319,6 +344,82 @@ def test_seed_gh_config_dir_preserves_existing_workspace_auth(tmp_path) -> None:
     seed_gh_config_dir(target_dir, source_dir=source_dir)
 
     assert (target_dir / "hosts.yml").read_text() == "github.com:\n  oauth_token: current\n"
+
+
+def test_refresh_gh_config_dir_overwrites_existing_workspace_auth(tmp_path) -> None:
+    source_dir = tmp_path / "source-gh"
+    source_dir.mkdir()
+    (source_dir / "hosts.yml").write_text("github.com:\n  oauth_token: fresh\n")
+    (source_dir / "config.yml").write_text("git_protocol: ssh\n")
+
+    target_dir = tmp_path / "workspace-gh"
+    target_dir.mkdir()
+    (target_dir / "hosts.yml").write_text("github.com:\n  oauth_token: stale\n")
+    (target_dir / "config.yml").write_text("git_protocol: https\n")
+
+    refresh_gh_config_dir(target_dir, source_dir=source_dir)
+
+    assert (target_dir / "hosts.yml").read_text() == "github.com:\n  oauth_token: fresh\n"
+    assert (target_dir / "config.yml").read_text() == "git_protocol: ssh\n"
+
+
+def test_recover_gh_auth_prefers_valid_workspace_auth(tmp_path, monkeypatch) -> None:
+    gh_dir = tmp_path / "workspace" / "gh"
+    source_dir = tmp_path / "default" / "gh"
+
+    refresh_calls: list[tuple[Path, Path | None]] = []
+    login_calls: list[Path] = []
+
+    monkeypatch.setattr("agendum.gh.auth_status", lambda path=None: path == gh_dir)
+    monkeypatch.setattr(
+        "agendum.gh.refresh_gh_config_dir",
+        lambda target, source_dir=None: refresh_calls.append((target, source_dir)),
+    )
+    monkeypatch.setattr("agendum.gh.auth_login", lambda target: login_calls.append(target) or True)
+
+    assert recover_gh_auth(gh_dir, source_dir=source_dir, interactive=True) is True
+    assert refresh_calls == []
+    assert login_calls == []
+
+
+def test_recover_gh_auth_refreshes_workspace_from_default_auth(tmp_path, monkeypatch) -> None:
+    gh_dir = tmp_path / "workspace" / "gh"
+    source_dir = tmp_path / "default" / "gh"
+    status_by_dir = {
+        gh_dir: False,
+        source_dir: True,
+    }
+    refresh_calls: list[tuple[Path, Path | None]] = []
+
+    def fake_auth_status(path=None):
+        return status_by_dir.get(path, False)
+
+    def fake_refresh(target, source_dir=None):
+        refresh_calls.append((target, source_dir))
+        status_by_dir[target] = True
+
+    monkeypatch.setattr("agendum.gh.auth_status", fake_auth_status)
+    monkeypatch.setattr("agendum.gh.refresh_gh_config_dir", fake_refresh)
+    monkeypatch.setattr("agendum.gh.auth_login", lambda _target: pytest.fail("unexpected interactive login"))
+
+    assert recover_gh_auth(gh_dir, source_dir=source_dir) is True
+    assert refresh_calls == [(gh_dir, source_dir)]
+
+
+def test_recover_gh_auth_falls_back_to_interactive_login(tmp_path, monkeypatch) -> None:
+    gh_dir = tmp_path / "workspace" / "gh"
+    source_dir = tmp_path / "default" / "gh"
+    login_calls: list[Path] = []
+
+    monkeypatch.setattr("agendum.gh.auth_status", lambda path=None: False)
+    monkeypatch.setattr(
+        "agendum.gh.refresh_gh_config_dir",
+        lambda _target, source_dir=None: pytest.fail(f"unexpected refresh from {source_dir}"),
+    )
+    monkeypatch.setattr("agendum.gh.auth_login", lambda target: login_calls.append(target) or True)
+
+    assert recover_gh_auth(gh_dir, source_dir=source_dir, interactive=True) is True
+    assert login_calls == [gh_dir]
 
 
 @pytest.mark.asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,13 @@ def test_first_run_setup_writes_private_escaped_config(
 
     monkeypatch.setattr(main, "CONFIG_DIR", config_dir)
     monkeypatch.setattr(main, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(main, "recover_gh_auth", lambda gh_path, interactive=False: gh_path == gh_dir and interactive)
+    monkeypatch.setattr(
+        main,
+        "recover_gh_auth",
+        lambda gh_path, interactive=False, force_refresh=False: (
+            gh_path == gh_dir and interactive and not force_refresh
+        ),
+    )
     monkeypatch.setattr("builtins.input", lambda _: 'example-"org')
 
     main.first_run_setup()
@@ -91,7 +97,9 @@ def test_main_recovers_default_workspace_gh_auth_before_launch(
     monkeypatch.setattr(
         main,
         "recover_gh_auth",
-        lambda gh_path, interactive=False: recover_calls.append((gh_path, interactive)) or True,
+        lambda gh_path, interactive=False, force_refresh=False: recover_calls.append(
+            (gh_path, interactive, force_refresh)
+        ) or True,
     )
     monkeypatch.setattr(main.sys, "argv", ["agendum"])
 
@@ -111,7 +119,7 @@ def test_main_recovers_default_workspace_gh_auth_before_launch(
 
     main.main()
 
-    assert recover_calls == [(gh_dir, False)]
+    assert recover_calls == [(gh_dir, False, False)]
     assert init_calls == [db_path]
     assert app_calls["ran"] is True
     assert app_calls["runtime"].gh_config_dir == gh_dir
@@ -125,17 +133,19 @@ def test_main_reauth_refreshes_base_workspace_auth(
     config_dir = tmp_path / ".agendum"
     gh_dir = config_dir / "gh"
 
-    calls: list[tuple[Path, bool]] = []
+    calls: list[tuple[Path, bool, bool]] = []
 
     monkeypatch.setattr(main, "CONFIG_DIR", config_dir)
     monkeypatch.setattr(
         main,
         "recover_gh_auth",
-        lambda gh_path, interactive=False: calls.append((gh_path, interactive)) or True,
+        lambda gh_path, interactive=False, force_refresh=False: calls.append(
+            (gh_path, interactive, force_refresh)
+        ) or True,
     )
     monkeypatch.setattr(main.sys, "argv", ["agendum", "reauth"])
 
     main.main()
 
-    assert calls == [(gh_dir, True)]
+    assert calls == [(gh_dir, True, True)]
     assert capsys.readouterr().out.strip() == f"Workspace gh auth ready at {gh_dir}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -13,10 +13,11 @@ def test_first_run_setup_writes_private_escaped_config(
 ) -> None:
     config_dir = tmp_path / ".agendum"
     config_path = config_dir / "config.toml"
+    gh_dir = config_dir / "gh"
 
     monkeypatch.setattr(main, "CONFIG_DIR", config_dir)
     monkeypatch.setattr(main, "CONFIG_PATH", config_path)
-    monkeypatch.setattr(main, "check_gh_cli", lambda: True)
+    monkeypatch.setattr(main, "recover_gh_auth", lambda gh_path, interactive=False: gh_path == gh_dir and interactive)
     monkeypatch.setattr("builtins.input", lambda _: 'example-"org')
 
     main.first_run_setup()
@@ -67,7 +68,7 @@ def test_demo_screenshots_command_dispatches(monkeypatch) -> None:
     assert called == [True]
 
 
-def test_main_bootstraps_default_workspace_gh_config_before_launch(
+def test_main_recovers_default_workspace_gh_auth_before_launch(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -79,7 +80,7 @@ def test_main_bootstraps_default_workspace_gh_config_before_launch(
     config_path.write_text("")
     db_path.touch()
 
-    seed_calls: list[tuple[Path, Path | None]] = []
+    recover_calls: list[tuple[Path, bool]] = []
     init_calls: list[Path] = []
     app_calls: dict[str, object] = {}
 
@@ -87,7 +88,11 @@ def test_main_bootstraps_default_workspace_gh_config_before_launch(
     monkeypatch.setattr(main, "CONFIG_PATH", config_path)
     monkeypatch.setattr(main, "DB_PATH", db_path)
     monkeypatch.setattr(main, "ensure_config", lambda path: AgendumConfig(orgs=["example-org"]))
-    monkeypatch.setattr(main, "seed_gh_config_dir", lambda gh_path, source_dir=None: seed_calls.append((gh_path, source_dir)))
+    monkeypatch.setattr(
+        main,
+        "recover_gh_auth",
+        lambda gh_path, interactive=False: recover_calls.append((gh_path, interactive)) or True,
+    )
     monkeypatch.setattr(main.sys, "argv", ["agendum"])
 
     from agendum import app as app_module
@@ -106,7 +111,31 @@ def test_main_bootstraps_default_workspace_gh_config_before_launch(
 
     main.main()
 
-    assert seed_calls == [(gh_dir, None)]
+    assert recover_calls == [(gh_dir, False)]
     assert init_calls == [db_path]
     assert app_calls["ran"] is True
     assert app_calls["runtime"].gh_config_dir == gh_dir
+
+
+def test_main_reauth_refreshes_base_workspace_auth(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch,
+) -> None:
+    config_dir = tmp_path / ".agendum"
+    gh_dir = config_dir / "gh"
+
+    calls: list[tuple[Path, bool]] = []
+
+    monkeypatch.setattr(main, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(
+        main,
+        "recover_gh_auth",
+        lambda gh_path, interactive=False: calls.append((gh_path, interactive)) or True,
+    )
+    monkeypatch.setattr(main.sys, "argv", ["agendum", "reauth"])
+
+    main.main()
+
+    assert calls == [(gh_dir, True)]
+    assert capsys.readouterr().out.strip() == f"Workspace gh auth ready at {gh_dir}"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -4,6 +4,7 @@ import pytest
 
 from agendum import __version__
 from agendum import __main__ as main
+from agendum.config import AgendumConfig
 
 
 def test_first_run_setup_writes_private_escaped_config(
@@ -64,3 +65,48 @@ def test_demo_screenshots_command_dispatches(monkeypatch) -> None:
     main.main()
 
     assert called == [True]
+
+
+def test_main_bootstraps_default_workspace_gh_config_before_launch(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    config_dir = tmp_path / ".agendum"
+    config_path = config_dir / "config.toml"
+    db_path = config_dir / "agendum.db"
+    gh_dir = config_dir / "gh"
+    config_dir.mkdir(parents=True)
+    config_path.write_text("")
+    db_path.touch()
+
+    seed_calls: list[tuple[Path, Path | None]] = []
+    init_calls: list[Path] = []
+    app_calls: dict[str, object] = {}
+
+    monkeypatch.setattr(main, "CONFIG_DIR", config_dir)
+    monkeypatch.setattr(main, "CONFIG_PATH", config_path)
+    monkeypatch.setattr(main, "DB_PATH", db_path)
+    monkeypatch.setattr(main, "ensure_config", lambda path: AgendumConfig(orgs=["example-org"]))
+    monkeypatch.setattr(main, "seed_gh_config_dir", lambda gh_path, source_dir=None: seed_calls.append((gh_path, source_dir)))
+    monkeypatch.setattr(main.sys, "argv", ["agendum"])
+
+    from agendum import app as app_module
+    from agendum import db as db_module
+
+    class FakeApp:
+        def __init__(self, *, runtime, config):
+            app_calls["runtime"] = runtime
+            app_calls["config"] = config
+
+        def run(self) -> None:
+            app_calls["ran"] = True
+
+    monkeypatch.setattr(app_module, "AgendumApp", FakeApp)
+    monkeypatch.setattr(db_module, "init_db", lambda path: init_calls.append(path))
+
+    main.main()
+
+    assert seed_calls == [(gh_dir, None)]
+    assert init_calls == [db_path]
+    assert app_calls["ran"] is True
+    assert app_calls["runtime"].gh_config_dir == gh_dir

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -295,6 +296,56 @@ async def test_run_sync_reports_missing_gh_auth(tmp_db: Path, monkeypatch) -> No
     assert changes == 0
     assert attention is False
     assert error == "gh credentials expired"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_keeps_workspace_gh_config_dir_when_global_changes(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    init_db(tmp_db)
+
+    from agendum import gh
+
+    workspace_gh_dir = tmp_db.parent / "gh"
+    switched_gh_dir = tmp_db.parent / "switched" / "gh"
+    observed_gh_dirs: list[Path | None] = []
+    switched = False
+
+    async def fake_run_gh(*args: str) -> str:
+        nonlocal switched
+        observed_gh_dirs.append(gh.get_gh_config_dir())
+        if not switched:
+            gh.set_gh_config_dir(switched_gh_dir)
+            switched = True
+
+        if args == ("api", "user", "--jq", ".login"):
+            return "author\n"
+        if args[:2] == ("api", "graphql"):
+            return json.dumps(authored_repo_payload(authored_prs=[]))
+        if args[:2] == ("api", "notifications"):
+            return "[]"
+        raise AssertionError(f"Unexpected gh call: {args}")
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    gh.set_gh_config_dir(workspace_gh_dir)
+    try:
+        changes, attention, error = await run_sync(
+            tmp_db,
+            AgendumConfig(repos=["example-org/example-repo"]),
+        )
+    finally:
+        gh.set_gh_config_dir(None)
+
+    assert changes == 0
+    assert attention is False
+    assert error is None
+    assert observed_gh_dirs == [
+        workspace_gh_dir,
+        workspace_gh_dir,
+        workspace_gh_dir,
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_syncer_edge_cases.py
+++ b/tests/test_syncer_edge_cases.py
@@ -322,6 +322,62 @@ async def test_run_sync_preserves_review_tasks_when_review_fetch_fails(
     assert task["status"] == "review requested", "Review task should not be closed when review fetch failed"
 
 
+async def test_run_sync_repo_only_preserves_review_tasks_without_review_discovery(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/org/repo/pull/11"
+    add_task(
+        tmp_db,
+        title="Review PR",
+        source="pr_review",
+        status="review requested",
+        gh_url=url,
+        gh_repo="org/repo",
+    )
+
+    async def fake_get_gh_username() -> str:
+        return "reviewer"
+
+    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
+        return {
+            "data": {
+                "repository": {
+                    "isArchived": False,
+                    "openIssues": {"nodes": []},
+                    "closedIssues": {"nodes": []},
+                    "authoredPRs": {"nodes": []},
+                    "mergedPRs": {"nodes": []},
+                    "closedPRs": {"nodes": []},
+                },
+            },
+        }
+
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == []
+        return [], True
+
+    async def fake_fetch_notifications(gh_user) -> list:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(repos=["org/repo"]))
+
+    assert changes == 0
+    assert attention is False
+    assert error is None
+    task = find_task_by_gh_url(tmp_db, url)
+    assert task is not None
+    assert task["status"] == "review requested"
+
+
 async def test_run_sync_closes_review_pr_as_done(
     tmp_db: Path, monkeypatch,
 ) -> None:
@@ -361,7 +417,7 @@ async def test_run_sync_closes_review_pr_as_done(
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(
-        tmp_db, AgendumConfig(repos=["org/repo"]),
+        tmp_db, AgendumConfig(orgs=["org"], repos=["org/repo"]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)


### PR DESCRIPTION
## Summary
- add workspace-aware runtime paths so each GitHub namespace gets isolated config, db, and `gh` state
- add an in-app namespace switch flow on `n` that suspends the TUI, runs `gh auth login`, and swaps the app onto the selected workspace
- bind sync-time `gh` subprocesses to the worker's workspace so namespace switches cannot leak credentials across in-flight syncs
- seed the default workspace `gh` config from the user's existing `gh` auth so upgraded installs keep working on launch
- reject invalid namespace input with a user-facing error instead of crashing

## Validation
- `uv run pytest tests/test_main.py tests/test_gh.py tests/test_syncer.py tests/test_app_interaction.py tests/test_config.py`

Closes #29