### PR TITLE
fix(ci): dispatch homebrew tap from release workflow

### DIFF
--- a/.github/workflows/dispatch-homebrew-tap.yml
+++ b/.github/workflows/dispatch-homebrew-tap.yml
@@ -1,38 +1,45 @@
 name: Dispatch Homebrew Tap
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Release tag to replay to the Homebrew tap, for example v0.3.0
+        required: true
+        type: string
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   dispatch:
     runs-on: ubuntu-latest
     env:
-      GH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+      GITHUB_TOKEN: ${{ github.token }}
       TARGET_REPO: danseely/homebrew-tap
       DISPATCH_EVENT_TYPE: agendum_release_published
       SOURCE_REPO: ${{ github.repository }}
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
-      RELEASE_URL: ${{ github.event.release.html_url }}
-      TARBALL_URL: ${{ github.event.release.tarball_url }}
-      PUBLISHED_AT: ${{ github.event.release.published_at }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+      HOMEBREW_TAP_DISPATCH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
     steps:
       - name: Dispatch release metadata to Homebrew tap
         shell: bash
         run: |
           set -euo pipefail
 
-          if [[ -z "${GH_TOKEN:-}" ]]; then
+          if [[ -z "${HOMEBREW_TAP_DISPATCH_TOKEN:-}" ]]; then
             echo "HOMEBREW_TAP_DISPATCH_TOKEN is required to dispatch to ${TARGET_REPO}." >&2
             exit 1
           fi
 
+          RELEASE_JSON=$(GH_TOKEN="${GITHUB_TOKEN}" gh api "/repos/${SOURCE_REPO}/releases/tags/${RELEASE_TAG}")
+          RELEASE_URL=$(jq -r '.html_url' <<<"${RELEASE_JSON}")
+          TARBALL_URL=$(jq -r '.tarball_url' <<<"${RELEASE_JSON}")
+          PUBLISHED_AT=$(jq -r '.published_at' <<<"${RELEASE_JSON}")
           VERSION="${RELEASE_TAG#v}"
 
           echo "Dispatching ${DISPATCH_EVENT_TYPE} to ${TARGET_REPO}."
-          if ! dispatch_output=$(gh api \
+          if ! dispatch_output=$(GH_TOKEN="${HOMEBREW_TAP_DISPATCH_TOKEN}" gh api \
             --method POST \
             -H "Accept: application/vnd.github+json" \
             "/repos/${TARGET_REPO}/dispatches" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,3 +62,43 @@ jobs:
           gh release create "${RELEASE_TAG}" dist/* \
             --title "${RELEASE_TAG}" \
             --generate-notes
+
+      - name: Dispatch Homebrew tap
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          HOMEBREW_TAP_DISPATCH_TOKEN: ${{ secrets.HOMEBREW_TAP_DISPATCH_TOKEN }}
+          TARGET_REPO: danseely/homebrew-tap
+          DISPATCH_EVENT_TYPE: agendum_release_published
+          RELEASE_TAG: ${{ steps.version.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${HOMEBREW_TAP_DISPATCH_TOKEN:-}" ]]; then
+            echo "HOMEBREW_TAP_DISPATCH_TOKEN is required to dispatch to ${TARGET_REPO}." >&2
+            exit 1
+          fi
+
+          RELEASE_JSON=$(gh api "/repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}")
+          RELEASE_URL=$(jq -r '.html_url' <<<"${RELEASE_JSON}")
+          TARBALL_URL=$(jq -r '.tarball_url' <<<"${RELEASE_JSON}")
+          PUBLISHED_AT=$(jq -r '.published_at' <<<"${RELEASE_JSON}")
+          VERSION="${RELEASE_TAG#v}"
+
+          echo "Dispatching ${DISPATCH_EVENT_TYPE} for ${RELEASE_TAG} to ${TARGET_REPO}."
+          if ! dispatch_output=$(GH_TOKEN="${HOMEBREW_TAP_DISPATCH_TOKEN}" gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${TARGET_REPO}/dispatches" \
+            -f event_type="${DISPATCH_EVENT_TYPE}" \
+            -F client_payload[source_repo]="${GITHUB_REPOSITORY}" \
+            -F client_payload[tag]="${RELEASE_TAG}" \
+            -F client_payload[version]="${VERSION}" \
+            -F client_payload[release_url]="${RELEASE_URL}" \
+            -F client_payload[tarball_url]="${TARBALL_URL}" \
+            -F client_payload[published_at]="${PUBLISHED_AT}" 2>&1); then
+            echo "Dispatch to ${TARGET_REPO} with event ${DISPATCH_EVENT_TYPE} failed." >&2
+            echo "${dispatch_output}" >&2
+            exit 1
+          fi
+
+          echo "Dispatch to ${TARGET_REPO} with event ${DISPATCH_EVENT_TYPE} succeeded."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,7 @@ The publish workflow:
 - creates an annotated git tag
 - builds `sdist` and wheel artifacts with `uv build`
 - publishes a GitHub release
+- dispatches the release payload to `danseely/homebrew-tap`
 
 For the first release, bootstrap one reachable release tag if none exists yet, then the rolling release PR automation takes over.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
 This repo uses Conventional Commits and SemVer. PR titles should also follow Conventional Commits so squash merges remain release-friendly. Keep PR titles as plain Conventional Commit subjects without extra prefixes.
 
 Merging a non-release PR into `main` creates or updates a rolling `release/next` PR with the version and changelog changes. If more PRs merge into `main` before release, that same release PR is updated in place and its target version is recalculated as needed. Merging the release PR publishes the GitHub tag and release.
-Publishing the GitHub release also dispatches `repository_dispatch` to `danseely/homebrew-tap` so the Homebrew tap can update from the release payload.
+That same `Release` workflow also dispatches `repository_dispatch` to `danseely/homebrew-tap` so the Homebrew tap can update from the release payload, rather than relying on a follow-on `release` event.
 
 The first release still needs a one-time bootstrap tag if `main` does not yet contain a reachable release tag.
 
@@ -98,11 +98,11 @@ From a maintainer point of view, the normal release flow is:
 3. Review the `release/next` PR and wait for its validation check to pass.
 4. Merge `release/next` when you want to ship.
 5. Wait for the `Release` workflow to publish the GitHub tag and release.
-6. Wait for the `Dispatch Homebrew Tap` workflow to notify `danseely/homebrew-tap`.
+6. Wait for the `Release` workflow to dispatch the release payload to `danseely/homebrew-tap`.
 7. Review and merge the Homebrew tap release PR after its CI passes.
 8. If you want the separate Homebrew `pr-pull` publish path, trigger that in the tap after the release PR merge.
 
-You should not normally need to run the tap workflow by hand. Manual replay is only for missed dispatches, failed automation, or debugging.
+You should not normally need to run the replay workflow by hand. `Dispatch Homebrew Tap` exists as a manual replay path for missed dispatches, failed automation, or debugging.
 
 ## Usage
 

--- a/docs/release-hardening.md
+++ b/docs/release-hardening.md
@@ -14,7 +14,7 @@ The normal operator flow is:
 2. Review the rolling `release/next` PR created or updated by automation.
 3. Merge `release/next` when ready to ship.
 4. Confirm that `release.yml` publishes the GitHub tag and release.
-5. Confirm that `dispatch-homebrew-tap.yml` dispatches the release payload to `danseely/homebrew-tap`.
+5. Confirm that `release.yml` dispatches the release payload to `danseely/homebrew-tap`.
 6. Review and merge the resulting tap PR after Homebrew CI passes.
 7. Trigger the tap's separate `pr-pull` publish path if you want bottles/publish handled through the standard Homebrew flow.
 
@@ -39,6 +39,8 @@ The release workflow assumes `GITHUB_TOKEN` has:
 
 - `contents: write` to create the annotated tag and publish the GitHub release
 
+The release workflow also assumes a repository secret named `HOMEBREW_TAP_DISPATCH_TOKEN` exists so it can notify `danseely/homebrew-tap` after the release is published.
+
 The rolling release PR workflow also needs repository write permissions for:
 
 - `contents: write`
@@ -47,7 +49,9 @@ The rolling release PR workflow also needs repository write permissions for:
 
 ## Homebrew tap dispatch
 
-After `release.yml` publishes a GitHub release, `.github/workflows/dispatch-homebrew-tap.yml` runs on the `release.published` event and sends a `repository_dispatch` to `danseely/homebrew-tap`.
+After `release.yml` publishes a GitHub release, that same workflow fetches the release metadata and sends a `repository_dispatch` to `danseely/homebrew-tap`.
+
+`.github/workflows/dispatch-homebrew-tap.yml` is the manual replay path. It accepts a release tag input and replays the same dispatch payload for an existing GitHub release.
 
 Use a dedicated repo secret named `HOMEBREW_TAP_DISPATCH_TOKEN` for the dispatch call. Keep that token scoped only to the tap repo and the `repository_dispatch` API path it needs; do not reuse `GITHUB_TOKEN` for cross-repo automation.
 
@@ -63,7 +67,7 @@ The dispatch contract is:
 
 Sequencing matters: the tap should treat `repository_dispatch` as the signal that the GitHub release already exists and can be consumed from the release URLs above. The tap should not assume source artifacts are available before the dispatch arrives.
 
-Operational fallback: if dispatch fails, rerun the `Dispatch Homebrew Tap` workflow from the Actions UI. If the workflow is unavailable, trigger the tap manually with the same `repository_dispatch` payload using `gh api` and the same token.
+Operational fallback: if dispatch fails, rerun `release.yml` if you want to replay the full publish handoff for that merge, or run `Dispatch Homebrew Tap` with the desired tag if you only want to replay the tap notification. If the workflow is unavailable, trigger the tap manually with the same `repository_dispatch` payload using `gh api` and the same token.
 
 ## Bootstrap flow
 


### PR DESCRIPTION
This fixes the release-to-Homebrew handoff by dispatching the tap directly from `release.yml` after the GitHub release is published, instead of relying on a follow-on `release` event that is suppressed when the release is created with `GITHUB_TOKEN`.

It also converts `dispatch-homebrew-tap.yml` into a manual replay workflow that accepts a release tag, so missed dispatches can be replayed intentionally.

Verification:
- parsed updated workflow YAML locally
- ran `git diff --check`