### PR TITLE
fix(syncer): close orphaned review tasks when repo drops from fetched_repos

### DIFF
--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -41,6 +41,9 @@ def diff_tasks(
     If *fetched_repos* is provided, only close tasks whose repo was
     actually fetched.  This prevents a partial API failure from
     wiping out items belonging to repos that simply weren't reached.
+    ``pr_review`` tasks are exempt from this guard — their completeness
+    is governed by *review_fetch_ok*, and their repo may no longer appear
+    in *fetched_repos* once GitHub drops the user from ``--review-requested``.
 
     If *review_fetch_ok* is False, review tasks are never closed
     (the review discovery may have returned incomplete results).
@@ -84,7 +87,10 @@ def diff_tasks(
             if not review_fetch_ok and task.get("source") == "pr_review":
                 continue
             # Only close items from repos we actually fetched data for.
-            if fetched_repos is not None:
+            # pr_review tasks are gated by review_fetch_ok instead — their
+            # repo may drop out of fetched_repos once GitHub removes the
+            # user from --review-requested.
+            if fetched_repos is not None and task.get("source") != "pr_review":
                 task_repo = task.get("gh_repo", "")
                 if task_repo not in fetched_repos:
                     continue

--- a/tests/test_syncer_edge_cases.py
+++ b/tests/test_syncer_edge_cases.py
@@ -43,6 +43,29 @@ def test_diff_detects_tag_change() -> None:
     assert result.to_update[0]["tags"] == '["new"]'
 
 
+def test_diff_closes_review_task_when_repo_not_in_fetched_repos() -> None:
+    """Review tasks must close via review_fetch_ok, regardless of fetched_repos.
+
+    Once GitHub drops the user from --review-requested, the repo may no
+    longer be in fetched_repos — but the review task must still close.
+    Authored/issue tasks keep the fetched_repos guard.
+    """
+    existing = [
+        {"id": 1, "source": "pr_review",
+         "gh_url": "https://github.com/org/other-repo/pull/1",
+         "gh_repo": "org/other-repo", "status": "review requested",
+         "title": "Review PR"},
+        {"id": 2, "source": "pr_authored",
+         "gh_url": "https://github.com/org/other-repo/pull/2",
+         "gh_repo": "org/other-repo", "status": "open", "title": "My PR"},
+    ]
+    result = diff_tasks(
+        existing, incoming=[], fetched_repos=set(), review_fetch_ok=True,
+    )
+    closed_ids = {t["id"] for t in result.to_close}
+    assert closed_ids == {1}
+
+
 def test_diff_detects_project_change() -> None:
     existing = [
         {"id": 1, "gh_url": "https://github.com/org/repo/pull/1",
@@ -419,6 +442,45 @@ async def test_run_sync_closes_review_pr_as_done(
     changes, attention, error = await run_sync(
         tmp_db, AgendumConfig(orgs=["org"], repos=["org/repo"]),
     )
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert task["status"] == "done"
+
+
+async def test_run_sync_closes_review_pr_when_repo_not_in_fetched_repos(
+    tmp_db: Path, monkeypatch,
+) -> None:
+    """Review task closes even when the repo drops out of discover_repos.
+
+    Once the user reviews, GitHub removes them from --review-requested, so
+    the repo is no longer surfaced by discover_repos and never makes it
+    into fetched_repos. The review task must still close.
+    """
+    init_db(tmp_db)
+    url = "https://github.com/org/other-repo/pull/100"
+    add_task(tmp_db, title="Review PR", source="pr_review",
+             status="review requested",
+             gh_url=url, gh_repo="org/other-repo")
+
+    async def fake_get_gh_username() -> str:
+        return "reviewer"
+
+    async def fake_discover_repos(orgs, gh_user) -> set:
+        return set()
+
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_fetch_notifications(gh_user) -> list:
+        return []
+
+    from agendum import gh
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "discover_repos", fake_discover_repos)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(orgs=["org"]))
 
     task = find_task_by_gh_url(tmp_db, url)
     assert task["status"] == "done"

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agendum"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- Review-request tasks got stuck on the list after the user submitted a review. Once GitHub drops the user from `--review-requested`, the PR's repo is no longer surfaced by `discover_repos` (assuming the user has no authored PR or assigned issue there), so the repo never enters `fetched_repos`. The `fetched_repos` guard in `diff_tasks` — intended to protect authored-PR/issue tasks from partial-fetch closure — was incorrectly blocking closure of `pr_review` tasks in that case.
- `pr_review` completeness is already gated by `review_fetch_ok`, which is the correct signal. This change exempts `pr_review` from the `fetched_repos` guard and updates the docstring to spell that out.
- Added a direct `diff_tasks` unit test (review task closes, sibling authored task does not) and a `run_sync` integration regression that stubs `discover_repos` to return `set()` while `discover_review_prs` returns `([], True)`.

Reproduction was `adadaptedinc/paas-service-api#100`: user reviewed, task stayed on the list indefinitely.

## Test plan
- [x] `uv run pytest tests/test_syncer_edge_cases.py -q` (new tests pass)
- [x] `uv run pytest -q` (full suite: 228 passed)
- [ ] Re-run local app, trigger a sync, confirm stuck review tasks close to `done`

🤖 Generated with [Claude Code](https://claude.com/claude-code)