### PR TITLE
feat(status): backlog + in-progress lifecycle for manual tasks

### DIFF
--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -538,6 +538,12 @@ class AgendumApp(App):
         elif action == "mark_reviewed":
             update_task(self._db_path, task_id, status="reviewed")
             self.refresh_table()
+        elif action == "mark_in_progress":
+            update_task(self._db_path, task_id, status="in progress")
+            self.refresh_table()
+        elif action == "mark_backlog":
+            update_task(self._db_path, task_id, status="backlog")
+            self.refresh_table()
         elif action == "remove":
             remove_task(self._db_path, task_id)
             self.refresh_table()
@@ -555,7 +561,7 @@ class AgendumApp(App):
             self._switch_namespace(value or None)
             return
 
-        add_task(self._db_path, title=value, source="manual", status="active")
+        add_task(self._db_path, title=value, source="manual", status="backlog")
         self.refresh_table()
 
     def _switch_namespace(self, namespace: str | None) -> None:

--- a/src/agendum/db.py
+++ b/src/agendum/db.py
@@ -44,6 +44,9 @@ def init_db(db_path: Path) -> None:
     db_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     conn = _connect(db_path)
     conn.executescript(SCHEMA)
+    # Migrate legacy manual-task status "active" → "backlog".
+    conn.execute("UPDATE tasks SET status='backlog' WHERE status='active'")
+    conn.commit()
     conn.close()
     os.chmod(db_path, 0o600)
 

--- a/src/agendum/demo.py
+++ b/src/agendum/demo.py
@@ -249,7 +249,7 @@ def seed_demo_data(db_path: Path) -> None:
         {
             "title": "hero shot",
             "source": "manual",
-            "status": "active",
+            "status": "in progress",
             "project": "screenshot-run",
             "tags": json.dumps(["manual", "screenshots"]),
             "seen": False,
@@ -257,7 +257,7 @@ def seed_demo_data(db_path: Path) -> None:
         {
             "title": "trim rows",
             "source": "manual",
-            "status": "active",
+            "status": "backlog",
             "project": "shot",
             "tags": json.dumps(["manual", "tuning"]),
             "seen": True,
@@ -265,7 +265,7 @@ def seed_demo_data(db_path: Path) -> None:
         {
             "title": "capture a second crop with the review section centered and enough extra rows visible to show how titles wrap once the table gets visually busy",
             "source": "manual",
-            "status": "active",
+            "status": "in progress",
             "project": "screenshot-run-wide",
             "tags": json.dumps(["manual", "framing"]),
             "seen": False,
@@ -273,7 +273,7 @@ def seed_demo_data(db_path: Path) -> None:
         {
             "title": "cleanup",
             "source": "manual",
-            "status": "active",
+            "status": "backlog",
             "project": "cleanup",
             "tags": json.dumps(["manual", "cleanup"]),
             "seen": True,

--- a/src/agendum/task_api.py
+++ b/src/agendum/task_api.py
@@ -165,7 +165,7 @@ def create_manual_task(
         db_path,
         title=title,
         source="manual",
-        status="active",
+        status="backlog",
         project=project,
         tags=tags_json,
     )

--- a/src/agendum/widgets.py
+++ b/src/agendum/widgets.py
@@ -22,9 +22,9 @@ STATUS_STYLES: dict[str, str] = {
     "review requested": "#a78bfa",
     "reviewed": "#7c6aad",
     "re-review requested": "#e879f9",
+    "backlog": "#c7a17a",
     "in progress": "#2dd4bf",
     "closed": "#888888",
-    "active": "#a3e635",
     "done": "#888888",
 }
 
@@ -92,6 +92,8 @@ _ACTION_LABELS: dict[str, str] = {
     "open_browser": "Open in browser",
     "remove": "Remove from board",
     "mark_reviewed": "Mark as reviewed",
+    "mark_in_progress": "Mark in progress",
+    "mark_backlog": "Move to backlog",
     "mark_done": "Mark done",
 }
 
@@ -150,12 +152,17 @@ class ActionModal(ModalScreen[str | None]):
 
     def _build_actions(self) -> list[tuple[str, str]]:
         source = self._task.get("source", "")
+        status = self._task.get("status", "")
         actions: list[tuple[str, str]] = []
         if self._task.get("gh_url"):
             actions.append(("open_browser", _ACTION_LABELS["open_browser"]))
         if source == "pr_review":
             actions.append(("mark_reviewed", _ACTION_LABELS["mark_reviewed"]))
         if source == "manual":
+            if status == "in progress":
+                actions.append(("mark_backlog", _ACTION_LABELS["mark_backlog"]))
+            else:
+                actions.append(("mark_in_progress", _ACTION_LABELS["mark_in_progress"]))
             actions.append(("mark_done", _ACTION_LABELS["mark_done"]))
         actions.append(("remove", _ACTION_LABELS["remove"]))
         return actions

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -108,7 +108,7 @@ async def test_table_width_stays_within_viewport(tmp_db) -> None:
         tmp_db,
         title="Fix the DataTable width-budget regression",
         source="manual",
-        status="active",
+        status="backlog",
         gh_author_name="Alexandria Stone",
         project="agendum",
     )
@@ -132,8 +132,8 @@ def test_stale_seen_delay_callback_is_ignored_after_workspace_switch(tmp_path) -
     init_db(original_db)
     init_db(switched_db)
 
-    original_task = add_task(original_db, title="Original", source="manual", status="active")
-    switched_task = add_task(switched_db, title="Switched", source="manual", status="active")
+    original_task = add_task(original_db, title="Original", source="manual", status="backlog")
+    switched_task = add_task(switched_db, title="Switched", source="manual", status="backlog")
     update_task(original_db, original_task, seen=0)
     update_task(switched_db, switched_task, seen=0)
 

--- a/tests/test_app_interaction.py
+++ b/tests/test_app_interaction.py
@@ -32,7 +32,7 @@ def _seed_tasks(tmp_db: Path) -> None:
              gh_author="author", gh_author_name="Author")
     add_task(tmp_db, title="An issue", source="issue", status="open",
              project="repo", gh_number=3, gh_url="https://github.com/org/repo/issues/3")
-    add_task(tmp_db, title="Manual task", source="manual", status="active")
+    add_task(tmp_db, title="Manual task", source="manual", status="backlog")
 
 
 # ── navigation ───────────────────────────────────────────────────────────
@@ -116,7 +116,7 @@ async def test_empty_input_cancelled(tmp_db: Path) -> None:
 
 async def test_mark_done_updates_status(tmp_db: Path) -> None:
     init_db(tmp_db)
-    task_id = add_task(tmp_db, title="Finish me", source="manual", status="active")
+    task_id = add_task(tmp_db, title="Finish me", source="manual", status="backlog")
     app = _app(tmp_db)
     # Directly invoke the handler to test the logic without modal interaction
     app._modal_task = {"id": task_id, "source": "manual", "gh_url": None}
@@ -142,9 +142,53 @@ async def test_mark_reviewed_updates_status(tmp_db: Path) -> None:
         assert task["status"] == "reviewed"
 
 
+async def test_mark_in_progress_updates_status(tmp_db: Path) -> None:
+    init_db(tmp_db)
+    task_id = add_task(tmp_db, title="Start this", source="manual", status="backlog")
+    app = _app(tmp_db)
+    app._modal_task = {"id": task_id, "source": "manual", "gh_url": None,
+                       "status": "backlog"}
+    app._db_path = tmp_db
+    async with app.run_test() as pilot:
+        app._handle_action("mark_in_progress")
+        await pilot.pause()
+        tasks = get_active_tasks(tmp_db)
+        assert tasks[0]["status"] == "in progress"
+
+
+async def test_mark_backlog_updates_status(tmp_db: Path) -> None:
+    init_db(tmp_db)
+    task_id = add_task(tmp_db, title="Pause this", source="manual", status="in progress")
+    app = _app(tmp_db)
+    app._modal_task = {"id": task_id, "source": "manual", "gh_url": None,
+                       "status": "in progress"}
+    app._db_path = tmp_db
+    async with app.run_test() as pilot:
+        app._handle_action("mark_backlog")
+        await pilot.pause()
+        tasks = get_active_tasks(tmp_db)
+        assert tasks[0]["status"] == "backlog"
+
+
+async def test_create_task_defaults_to_backlog(tmp_db: Path) -> None:
+    init_db(tmp_db)
+    app = _app(tmp_db)
+    async with app.run_test() as pilot:
+        inp = app.query_one("#create-input")
+        inp.focus()
+        await pilot.pause()
+        inp.value = "Write the post"
+        await pilot.press("enter")
+        await pilot.pause()
+        tasks = get_active_tasks(tmp_db)
+        assert len(tasks) == 1
+        assert tasks[0]["title"] == "Write the post"
+        assert tasks[0]["status"] == "backlog"
+
+
 async def test_remove_deletes_task(tmp_db: Path) -> None:
     init_db(tmp_db)
-    task_id = add_task(tmp_db, title="Remove me", source="manual", status="active")
+    task_id = add_task(tmp_db, title="Remove me", source="manual", status="backlog")
     app = _app(tmp_db)
     app._modal_task = {"id": task_id, "source": "manual", "gh_url": None}
     async with app.run_test() as pilot:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -19,13 +19,13 @@ def test_init_db_is_idempotent(tmp_db: Path) -> None:
 
 def test_add_manual_task(tmp_db: Path) -> None:
     init_db(tmp_db)
-    task_id = add_task(tmp_db, title="Write docs", source="manual", status="active")
+    task_id = add_task(tmp_db, title="Write docs", source="manual", status="backlog")
     assert isinstance(task_id, int)
     tasks = get_active_tasks(tmp_db)
     assert len(tasks) == 1
     assert tasks[0]["title"] == "Write docs"
     assert tasks[0]["source"] == "manual"
-    assert tasks[0]["status"] == "active"
+    assert tasks[0]["status"] == "backlog"
     assert tasks[0]["seen"] == 1
 
 
@@ -50,7 +50,7 @@ def test_add_github_task(tmp_db: Path) -> None:
 
 def test_update_task(tmp_db: Path) -> None:
     init_db(tmp_db)
-    task_id = add_task(tmp_db, title="Test", source="manual", status="active")
+    task_id = add_task(tmp_db, title="Test", source="manual", status="backlog")
     update_task(tmp_db, task_id, status="done", seen=0)
     conn = sqlite3.connect(tmp_db)
     conn.row_factory = sqlite3.Row
@@ -62,7 +62,7 @@ def test_update_task(tmp_db: Path) -> None:
 
 def test_get_active_tasks_excludes_terminal(tmp_db: Path) -> None:
     init_db(tmp_db)
-    add_task(tmp_db, title="Open", source="manual", status="active")
+    add_task(tmp_db, title="Open", source="manual", status="backlog")
     add_task(tmp_db, title="Done", source="manual", status="done")
     add_task(tmp_db, title="Merged", source="pr_authored", status="merged")
     add_task(tmp_db, title="Closed", source="issue", status="closed")
@@ -73,10 +73,28 @@ def test_get_active_tasks_excludes_terminal(tmp_db: Path) -> None:
 
 def test_remove_task(tmp_db: Path) -> None:
     init_db(tmp_db)
-    task_id = add_task(tmp_db, title="Delete me", source="manual", status="active")
+    task_id = add_task(tmp_db, title="Delete me", source="manual", status="backlog")
     remove_task(tmp_db, task_id)
     tasks = get_active_tasks(tmp_db)
     assert len(tasks) == 0
+
+
+def test_init_db_migrates_active_to_backlog(tmp_db: Path) -> None:
+    init_db(tmp_db)
+    conn = sqlite3.connect(tmp_db)
+    conn.execute(
+        """INSERT INTO tasks (title, source, status, last_changed_at)
+           VALUES (?, ?, ?, datetime('now'))""",
+        ("Legacy", "manual", "active"),
+    )
+    conn.commit()
+    conn.close()
+
+    init_db(tmp_db)
+
+    tasks = get_active_tasks(tmp_db)
+    assert len(tasks) == 1
+    assert tasks[0]["status"] == "backlog"
 
 
 def test_gh_url_unique_constraint(tmp_db: Path) -> None:

--- a/tests/test_db_edge_cases.py
+++ b/tests/test_db_edge_cases.py
@@ -9,8 +9,8 @@ from agendum.db import add_task, get_active_tasks, init_db, mark_all_seen, updat
 
 def test_mark_all_seen(tmp_db: Path) -> None:
     init_db(tmp_db)
-    id1 = add_task(tmp_db, title="Unseen 1", source="manual", status="active")
-    id2 = add_task(tmp_db, title="Unseen 2", source="manual", status="active")
+    id1 = add_task(tmp_db, title="Unseen 1", source="manual", status="backlog")
+    id2 = add_task(tmp_db, title="Unseen 2", source="manual", status="backlog")
     update_task(tmp_db, id1, seen=0)
     update_task(tmp_db, id2, seen=0)
 
@@ -22,7 +22,7 @@ def test_mark_all_seen(tmp_db: Path) -> None:
 
 def test_mark_all_seen_sets_last_seen_at(tmp_db: Path) -> None:
     init_db(tmp_db)
-    task_id = add_task(tmp_db, title="Check timestamp", source="manual", status="active")
+    task_id = add_task(tmp_db, title="Check timestamp", source="manual", status="backlog")
     update_task(tmp_db, task_id, seen=0)
 
     mark_all_seen(tmp_db)
@@ -33,7 +33,7 @@ def test_mark_all_seen_sets_last_seen_at(tmp_db: Path) -> None:
 
 def test_mark_all_seen_noop_when_all_seen(tmp_db: Path) -> None:
     init_db(tmp_db)
-    add_task(tmp_db, title="Already seen", source="manual", status="active")
+    add_task(tmp_db, title="Already seen", source="manual", status="backlog")
     # Should not raise
     mark_all_seen(tmp_db)
     tasks = get_active_tasks(tmp_db)
@@ -42,14 +42,14 @@ def test_mark_all_seen_noop_when_all_seen(tmp_db: Path) -> None:
 
 def test_update_task_rejects_invalid_columns(tmp_db: Path) -> None:
     init_db(tmp_db)
-    task_id = add_task(tmp_db, title="Bad update", source="manual", status="active")
+    task_id = add_task(tmp_db, title="Bad update", source="manual", status="backlog")
     with pytest.raises(ValueError, match="Invalid column names"):
         update_task(tmp_db, task_id, evil_column="drop table")
 
 
 def test_update_task_noop_with_no_fields(tmp_db: Path) -> None:
     init_db(tmp_db)
-    task_id = add_task(tmp_db, title="Noop", source="manual", status="active")
+    task_id = add_task(tmp_db, title="Noop", source="manual", status="backlog")
     # Should not raise or execute SQL
     update_task(tmp_db, task_id)
     tasks = get_active_tasks(tmp_db)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,7 +16,7 @@ async def test_table_displays_grouped_tasks(tmp_db: Path) -> None:
              gh_author="reviewer", gh_author_name="Reviewer")
     add_task(tmp_db, title="add missing type exports", source="issue", status="open",
              project="example-repo", gh_number=98, gh_url="https://github.com/example-org/example-repo/issues/98")
-    add_task(tmp_db, title="update docs", source="manual", status="active")
+    add_task(tmp_db, title="update docs", source="manual", status="backlog")
 
     config = AgendumConfig(orgs=[], sync_interval=9999)
     app = AgendumApp(db_path=tmp_db, config=config)

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -123,7 +123,7 @@ def test_diff_detects_closed_task() -> None:
 
 def test_diff_ignores_manual_tasks() -> None:
     existing = [
-        {"id": 1, "gh_url": None, "status": "active", "title": "Manual", "source": "manual"},
+        {"id": 1, "gh_url": None, "status": "backlog", "title": "Manual", "source": "manual"},
     ]
     incoming: list[dict] = []
     result = diff_tasks(existing, incoming)

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -69,7 +69,7 @@ def test_search_tasks_matches_across_fields(tmp_db: Path, query: str, title: str
         tmp_db,
         title="Heartbeat Title Match",
         source="manual",
-        status="active",
+        status="backlog",
     )
     add_task(
         tmp_db,
@@ -113,7 +113,7 @@ def test_search_tasks_matches_across_fields(tmp_db: Path, query: str, title: str
         tmp_db,
         title="Tags Match",
         source="manual",
-        status="active",
+        status="backlog",
         tags='["urgent", "review"]',
     )
     add_task(
@@ -139,7 +139,7 @@ def test_get_task_returns_present_and_missing(tmp_db: Path) -> None:
         tmp_db,
         title="Lookup me",
         source="manual",
-        status="active",
+        status="backlog",
         tags='["one"]',
     )
 
@@ -157,7 +157,7 @@ def test_create_manual_task_sets_defaults_and_tags(tmp_db: Path) -> None:
 
     assert task["title"] == "Write docs"
     assert task["source"] == "manual"
-    assert task["status"] == "active"
+    assert task["status"] == "backlog"
     assert task["project"] == "docs"
     assert task["tags"] == ["alpha", "beta"]
 

--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -38,7 +38,7 @@ class TestStyledStatus:
             ("re-review requested", "#e879f9"),
             ("reviewed", "#7c6aad"),
             ("in progress", "#2dd4bf"),
-            ("active", "#a3e635"),
+            ("backlog", "#c7a17a"),
             ("done", "#888888"),
         ],
     )
@@ -150,6 +150,22 @@ class TestActionModal:
         action_ids = [a[0] for a in actions]
         assert "mark_done" in action_ids
         assert "mark_reviewed" not in action_ids
+
+    def test_manual_backlog_has_mark_in_progress(self) -> None:
+        task = {"source": "manual", "status": "backlog", "title": "Task"}
+        modal = ActionModal(task)
+        action_ids = [a[0] for a in modal._build_actions()]
+        assert "mark_in_progress" in action_ids
+        assert "mark_backlog" not in action_ids
+        assert "mark_done" in action_ids
+
+    def test_manual_in_progress_has_mark_backlog(self) -> None:
+        task = {"source": "manual", "status": "in progress", "title": "Task"}
+        modal = ActionModal(task)
+        action_ids = [a[0] for a in modal._build_actions()]
+        assert "mark_backlog" in action_ids
+        assert "mark_in_progress" not in action_ids
+        assert "mark_done" in action_ids
 
     def test_no_gh_url_omits_open_browser(self) -> None:
         task = {"source": "manual", "title": "No URL"}


### PR DESCRIPTION
## Summary
- Manual tasks now open in `backlog` instead of `active`. The task modal lets you transition between `backlog` and `in progress` (showing "Mark in progress" or "Move to backlog" based on current status), in addition to existing mark-done and remove actions.
- The legacy `active` status is removed entirely — it was only ever used as the manual-task default, with no GitHub-derived code paths or filters depending on it. `init_db` runs a one-shot idempotent migration (`UPDATE tasks SET status='backlog' WHERE status='active'`) so existing dev DBs transition on next launch.
- New color: `backlog = #c7a17a` (warm tan), placed in the issues/manual gradient between `open` blue and `in progress` teal. `in progress` keeps its existing teal `#2dd4bf`.
- Demo seeds now display a mix of `backlog` and `in progress` manual tasks so screenshots reflect the new lifecycle.

## Test plan
- [x] `uv run pytest -q` (234 passed; +6 new tests)
  - modal action lists for `backlog` / `in progress` manual tasks
  - `mark_in_progress` / `mark_backlog` handlers
  - create-task default is `backlog`
  - `init_db` migrates `active` → `backlog`
  - palette parametrize covers `backlog`; `active` removed
- [x] Local smoke: launched app, created a manual task (lands in backlog, tan color), opened modal → "Mark in progress" → color flips to teal, "Move to backlog" → back to tan, "Mark done" → removed from active list

🤖 Generated with [Claude Code](https://claude.com/claude-code)