### PR TITLE
chore(sync): raise default poll interval to 120s

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ orgs = ["example-org"]
 exclude_repos = []
 
 [sync]
-interval = 60
+interval = 120
 
 [display]
 seen_delay = 3

--- a/src/agendum/app.py
+++ b/src/agendum/app.py
@@ -645,7 +645,7 @@ class AgendumApp(App):
         now_wall = time.time()
         mono_elapsed = now_mono - self._last_sync_mono
         wall_elapsed = now_wall - self._last_sync_wall
-        interval = self._config.sync_interval if self._config else 60
+        interval = self._config.sync_interval if self._config else 120
 
         # Drift = how much more the wall clock advanced than monotonic.
         # On macOS sleep this equals the sleep duration.

--- a/src/agendum/config.py
+++ b/src/agendum/config.py
@@ -25,7 +25,7 @@ exclude_repos = []
 
 [sync]
 # Poll interval in seconds
-interval = 60
+interval = 120
 
 [display]
 # Seconds after focus before marking items seen
@@ -38,7 +38,7 @@ class AgendumConfig:
     orgs: list[str] = field(default_factory=list)
     repos: list[str] = field(default_factory=list)
     exclude_repos: list[str] = field(default_factory=list)
-    sync_interval: int = 60
+    sync_interval: int = 120
     seen_delay: int = 3
 
 
@@ -124,7 +124,7 @@ def load_config(path: Path | None = None) -> AgendumConfig:
         orgs=gh.get("orgs", []),
         repos=gh.get("repos", []),
         exclude_repos=gh.get("exclude_repos", []),
-        sync_interval=sync.get("interval", 60),
+        sync_interval=sync.get("interval", 120),
         seen_delay=display.get("seen_delay", 3),
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -16,7 +16,7 @@ from agendum.config import (
 
 def test_default_config_when_no_file(tmp_path: Path) -> None:
     config = load_config(tmp_path / "nonexistent.toml")
-    assert config.sync_interval == 60
+    assert config.sync_interval == 120
     assert config.seen_delay == 3
     assert config.orgs == []
     assert config.repos == []
@@ -53,7 +53,7 @@ orgs = ["example-org"]
 """)
     config = load_config(config_path)
     assert config.orgs == ["example-org"]
-    assert config.sync_interval == 60
+    assert config.sync_interval == 120
     assert config.seen_delay == 3
 
 


### PR DESCRIPTION
## Summary
- Bump `sync.interval` default from 60s to 120s (config default, dataclass default, loader fallback, and app fallback)
- Update README example and the two default-assertion tests to match
- Halves baseline GitHub GraphQL usage with no meaningful UX hit — manual `r` sync is still one keystroke away

## Context
With ~35 repos discovered in a typical workspace, each sync costs ~35 GraphQL calls + a handful of REST search/core calls. At 60s that's ~42% of the 5000/hr GraphQL budget; 120s halves it and leaves real headroom for review-detail spikes.

## Test plan
- [x] \`uv run pytest tests/test_config.py tests/test_app.py\` passes (37 tests)
- [ ] Fresh \`~/.agendum/config.toml\` is written with \`interval = 120\`
- [ ] Existing configs that explicitly set \`interval\` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)