### PR TITLE
chore(release): include uv.lock in release PR bumps

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -73,7 +73,9 @@ jobs:
         if: steps.next.outputs.skip != 'true'
         env:
           NEXT_VERSION: ${{ steps.next.outputs.next_version }}
-        run: uv run cz bump --yes --changelog --files-only "${NEXT_VERSION}"
+        run: |
+          uv run cz bump --yes --changelog --files-only "${NEXT_VERSION}"
+          uv lock
 
       - name: Create or update release PR
         if: steps.next.outputs.skip != 'true'
@@ -88,6 +90,7 @@ jobs:
 
             This PR was created from the latest merged changes on `main` and contains:
             - version file updates
+            - lockfile updates
             - changelog updates
 
             This is a rolling release PR. Additional merges to `main` will update this PR in place, including recalculating the release version when needed.

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agendum"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
## Summary
- run `uv lock` during release PR preparation so the lockfile stays in sync with version bumps
- include the one-time `uv.lock` catch-up for the current `0.5.1` drift
- mention lockfile updates in the automated release PR body

## Why
The rolling release workflow updates version files and changelog content, but it was leaving `uv.lock` stale. That produced a recurring one-line lockfile diff after each release.

## Validation
- `uv run pre-commit run --files .github/workflows/create-release-pr.yml uv.lock`

closes #47