### PR TITLE
refactor(sync): switch GitHub sync to search-first discovery

### DIFF
--- a/src/agendum/db.py
+++ b/src/agendum/db.py
@@ -140,6 +140,25 @@ def find_task_by_gh_url(db_path: Path, gh_url: str) -> dict | None:
     return dict(row) if row else None
 
 
+def find_tasks_by_gh_urls(db_path: Path, gh_urls: list[str]) -> dict[str, dict]:
+    if not gh_urls:
+        return {}
+
+    unique_urls = list(dict.fromkeys(gh_urls))
+    placeholders = ", ".join("?" for _ in unique_urls)
+    conn = _connect(db_path)
+    rows = conn.execute(
+        f"SELECT * FROM tasks WHERE gh_url IN ({placeholders})",
+        unique_urls,
+    ).fetchall()
+    conn.close()
+    return {
+        row["gh_url"]: dict(row)
+        for row in rows
+        if row["gh_url"] is not None
+    }
+
+
 def mark_all_seen(db_path: Path) -> None:
     now = datetime.now(timezone.utc).isoformat()
     conn = _connect(db_path)

--- a/src/agendum/db.py
+++ b/src/agendum/db.py
@@ -28,6 +28,12 @@ CREATE TABLE IF NOT EXISTS tasks (
 CREATE INDEX IF NOT EXISTS idx_tasks_source ON tasks(source);
 CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_gh_url ON tasks(gh_url) WHERE gh_url IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS sync_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
 """
 
 
@@ -157,6 +163,31 @@ def find_tasks_by_gh_urls(db_path: Path, gh_urls: list[str]) -> dict[str, dict]:
         for row in rows
         if row["gh_url"] is not None
     }
+
+
+def get_sync_state(db_path: Path, key: str) -> str | None:
+    conn = _connect(db_path)
+    row = conn.execute(
+        "SELECT value FROM sync_state WHERE key = ?",
+        (key,),
+    ).fetchone()
+    conn.close()
+    return row["value"] if row else None
+
+
+def set_sync_state(db_path: Path, key: str, value: str) -> None:
+    now = datetime.now(timezone.utc).isoformat()
+    conn = _connect(db_path)
+    conn.execute(
+        """INSERT INTO sync_state (key, value, updated_at)
+           VALUES (?, ?, ?)
+           ON CONFLICT(key) DO UPDATE SET
+               value = excluded.value,
+               updated_at = excluded.updated_at""",
+        (key, value, now),
+    )
+    conn.commit()
+    conn.close()
 
 
 def mark_all_seen(db_path: Path) -> None:

--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -22,6 +22,8 @@ _TASK_GH_CONFIG_DIR: ContextVar[Path | None | object] = ContextVar(
     "agendum_task_gh_config_dir",
     default=_GH_CONFIG_DIR_UNSET,
 )
+DEFAULT_SEARCH_PAGE_SIZE = 50
+DEFAULT_HYDRATE_BATCH_SIZE = 25
 
 
 # ---------------------------------------------------------------------------
@@ -474,40 +476,416 @@ query($owner: String!, $name: String!, $number: Int!) {
 }
 """
 
+SEARCH_PULL_REQUESTS_QUERY = """
+query($query: String!, $first: Int!, $after: String) {
+  search(type: ISSUE, query: $query, first: $first, after: $after) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on PullRequest {
+        id
+        number
+        title
+        url
+        state
+        isDraft
+        reviewDecision
+        repository { nameWithOwner }
+        labels(first: 10) { nodes { name } }
+        author {
+          login
+          ... on User {
+            name
+          }
+        }
+        reviewRequests(first: 10) { totalCount }
+      }
+    }
+  }
+}
+"""
+
+SEARCH_ISSUES_QUERY = """
+query($query: String!, $first: Int!, $after: String) {
+  search(type: ISSUE, query: $query, first: $first, after: $after) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on Issue {
+        id
+        number
+        title
+        url
+        state
+        repository { nameWithOwner }
+        labels(first: 10) { nodes { name } }
+      }
+    }
+  }
+}
+"""
+
+PULL_REQUEST_NODE_FRAGMENT = """
+... on PullRequest {
+  id
+  number
+  title
+  url
+  state
+  isDraft
+  reviewDecision
+  repository { nameWithOwner }
+  labels(first: 10) { nodes { name } }
+  author {
+    login
+    ... on User {
+      name
+    }
+  }
+  reviewRequests(first: 10) { totalCount }
+  commits(last: 1) {
+    nodes {
+      commit {
+        committedDate
+      }
+    }
+  }
+  reviews(last: 50) {
+    nodes {
+      id
+      state
+      submittedAt
+      author { login }
+    }
+  }
+  reviewThreads(last: 50) {
+    nodes {
+      isResolved
+      isOutdated
+      comments(last: 20) {
+        nodes {
+          createdAt
+          pullRequestReview { id }
+          author { login }
+        }
+      }
+    }
+  }
+  timelineItems(last: 50, itemTypes: [REVIEW_REQUESTED_EVENT]) {
+    nodes {
+      ... on ReviewRequestedEvent {
+        createdAt
+        requestedReviewer {
+          ... on User { login }
+        }
+      }
+    }
+  }
+}
+"""
+
+ISSUE_NODE_FRAGMENT = """
+... on Issue {
+  id
+  number
+  title
+  url
+  state
+  repository { nameWithOwner }
+  labels(first: 10) { nodes { name } }
+  timelineItems(last: 20, itemTypes: [CONNECTED_EVENT, CROSS_REFERENCED_EVENT]) {
+    nodes {
+      ... on ConnectedEvent { subject { ... on PullRequest { url } } }
+      ... on CrossReferencedEvent { source { ... on PullRequest { url } } }
+    }
+  }
+}
+"""
+
+
+def _load_json_payload(payload: str, *, context: str) -> Any | None:
+    if not payload:
+        return None
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        log.warning("Failed to parse JSON payload for %s", context)
+        return None
+
+
+def _search_query_for_org(*, org: str, qualifiers: str) -> str:
+    return f"org:{org} {qualifiers}"
+
+
+async def _search_items_for_org(
+    *,
+    org: str,
+    qualifiers: str,
+    query: str,
+    page_size: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    items: list[dict[str, Any]] = []
+    ok = True
+    after: str | None = None
+
+    while True:
+        args = [
+            "api", "graphql",
+            "-f", f"query={query}",
+            "-F", f"query={_search_query_for_org(org=org, qualifiers=qualifiers)}",
+            "-F", f"first={page_size}",
+        ]
+        if after:
+            args.extend(["-F", f"after={after}"])
+
+        payload = _load_json_payload(
+            await _run_gh(*args),
+            context=f"search items for {org}",
+        )
+        if payload is None:
+            ok = False
+            break
+
+        search = (payload.get("data") or {}).get("search") or {}
+        nodes = search.get("nodes") or []
+        items.extend(node for node in nodes if node)
+
+        page_info = search.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+
+        after = page_info.get("endCursor")
+        if not after:
+            ok = False
+            break
+
+    return items, ok
+
+
+async def _search_items_across_orgs(
+    orgs: list[str],
+    *,
+    qualifiers: str,
+    query: str,
+    page_size: int,
+) -> tuple[list[dict[str, Any]], bool]:
+    items: list[dict[str, Any]] = []
+    ok = True
+    seen_ids: set[str] = set()
+
+    for org in orgs:
+        org_items, org_ok = await _search_items_for_org(
+            org=org,
+            qualifiers=qualifiers,
+            query=query,
+            page_size=page_size,
+        )
+        ok = ok and org_ok
+        for item in org_items:
+            node_id = item.get("id")
+            if node_id and node_id in seen_ids:
+                continue
+            if node_id:
+                seen_ids.add(node_id)
+            items.append(item)
+
+    return items, ok
+
+
+def _build_node_batch_query(node_ids: list[str], *, fragment: str) -> str:
+    aliases: list[str] = []
+    for index, node_id in enumerate(node_ids):
+        aliases.append(
+            f"  n{index}: node(id: {json.dumps(node_id)}) {{\n{fragment}\n  }}"
+        )
+    return "query {\n" + "\n".join(aliases) + "\n}"
+
+
+async def _hydrate_node_batches(
+    node_ids: list[str],
+    *,
+    fragment: str,
+    batch_size: int,
+    context: str,
+) -> tuple[list[dict[str, Any]], bool]:
+    items: list[dict[str, Any]] = []
+    ok = True
+
+    for start in range(0, len(node_ids), batch_size):
+        batch = node_ids[start:start + batch_size]
+        if not batch:
+            continue
+
+        payload = _load_json_payload(
+            await _run_gh(
+                "api", "graphql",
+                "-f", f"query={_build_node_batch_query(batch, fragment=fragment)}",
+            ),
+            context=context,
+        )
+        if payload is None:
+            ok = False
+            continue
+
+        data = payload.get("data") or {}
+        for index in range(len(batch)):
+            node = data.get(f"n{index}")
+            if node:
+                items.append(node)
+
+    return items, ok
+
 
 async def fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
     """Fetch all relevant data for a single repo via GraphQL."""
-    result = await _run_gh(
+    payload = _load_json_payload(
+        await _run_gh(
         "api", "graphql",
         "-f", f"query={REPO_QUERY}",
         "-F", f"owner={owner}",
         "-F", f"name={name}",
         "-F", f"user={gh_user}",
+        ),
+        context=f"repo data for {owner}/{name}",
     )
-    if not result:
-        return {}
-    try:
-        return json.loads(result)
-    except json.JSONDecodeError:
-        log.warning("Failed to parse GraphQL response for %s/%s", owner, name)
-        return {}
+    return payload or {}
 
 
 async def fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
     """Fetch review detail for a single PR to determine review status."""
-    result = await _run_gh(
+    payload = _load_json_payload(
+        await _run_gh(
         "api", "graphql",
         "-f", f"query={REVIEW_QUERY}",
         "-F", f"owner={owner}",
         "-F", f"name={name}",
         "-F", f"number={number}",
+        ),
+        context=f"review detail for {owner}/{name}#{number}",
     )
-    if not result:
-        return {}
-    try:
-        return json.loads(result)
-    except json.JSONDecodeError:
-        return {}
+    return payload or {}
+
+
+async def search_authored_prs(
+    orgs: list[str],
+    gh_user: str,
+    *,
+    page_size: int = DEFAULT_SEARCH_PAGE_SIZE,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Search open authored PRs across orgs via GraphQL search."""
+    return await _search_items_across_orgs(
+        orgs,
+        qualifiers=f"is:open is:pr author:{gh_user}",
+        query=SEARCH_PULL_REQUESTS_QUERY,
+        page_size=page_size,
+    )
+
+
+async def search_merged_authored_prs(
+    orgs: list[str],
+    gh_user: str,
+    *,
+    page_size: int = DEFAULT_SEARCH_PAGE_SIZE,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Search merged authored PRs across orgs via GraphQL search."""
+    return await _search_items_across_orgs(
+        orgs,
+        qualifiers=f"is:merged is:pr author:{gh_user}",
+        query=SEARCH_PULL_REQUESTS_QUERY,
+        page_size=page_size,
+    )
+
+
+async def search_closed_authored_prs(
+    orgs: list[str],
+    gh_user: str,
+    *,
+    page_size: int = DEFAULT_SEARCH_PAGE_SIZE,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Search closed, unmerged authored PRs across orgs via GraphQL search."""
+    return await _search_items_across_orgs(
+        orgs,
+        qualifiers=f"is:closed -is:merged is:pr author:{gh_user}",
+        query=SEARCH_PULL_REQUESTS_QUERY,
+        page_size=page_size,
+    )
+
+
+async def search_assigned_issues(
+    orgs: list[str],
+    gh_user: str,
+    *,
+    page_size: int = DEFAULT_SEARCH_PAGE_SIZE,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Search open assigned issues across orgs via GraphQL search."""
+    return await _search_items_across_orgs(
+        orgs,
+        qualifiers=f"is:open is:issue assignee:{gh_user}",
+        query=SEARCH_ISSUES_QUERY,
+        page_size=page_size,
+    )
+
+
+async def search_closed_issues(
+    orgs: list[str],
+    gh_user: str,
+    *,
+    page_size: int = DEFAULT_SEARCH_PAGE_SIZE,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Search closed assigned issues across orgs via GraphQL search."""
+    return await _search_items_across_orgs(
+        orgs,
+        qualifiers=f"is:closed is:issue assignee:{gh_user}",
+        query=SEARCH_ISSUES_QUERY,
+        page_size=page_size,
+    )
+
+
+async def search_review_requested_prs(
+    orgs: list[str],
+    gh_user: str,
+    *,
+    page_size: int = DEFAULT_SEARCH_PAGE_SIZE,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Search open review-requested PRs across orgs via GraphQL search."""
+    return await _search_items_across_orgs(
+        orgs,
+        qualifiers=f"is:open is:pr review-requested:{gh_user}",
+        query=SEARCH_PULL_REQUESTS_QUERY,
+        page_size=page_size,
+    )
+
+
+async def hydrate_pull_requests(
+    node_ids: list[str],
+    *,
+    batch_size: int = DEFAULT_HYDRATE_BATCH_SIZE,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Hydrate pull requests by GraphQL node id in bounded batches."""
+    return await _hydrate_node_batches(
+        node_ids,
+        fragment=PULL_REQUEST_NODE_FRAGMENT,
+        batch_size=batch_size,
+        context="pull request hydration",
+    )
+
+
+async def hydrate_issues(
+    node_ids: list[str],
+    *,
+    batch_size: int = DEFAULT_HYDRATE_BATCH_SIZE,
+) -> tuple[list[dict[str, Any]], bool]:
+    """Hydrate issues by GraphQL node id in bounded batches."""
+    return await _hydrate_node_batches(
+        node_ids,
+        fragment=ISSUE_NODE_FRAGMENT,
+        batch_size=batch_size,
+        context="issue hydration",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -592,14 +970,12 @@ async def discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict]
 
 async def fetch_notifications(gh_user: str) -> list[dict]:
     """Fetch unread GitHub notifications."""
-    out = await _run_gh(
+    payload = _load_json_payload(
+        await _run_gh(
         "api", "notifications",
         "--method", "GET",
         "-f", "all=false",
+        ),
+        context="notifications",
     )
-    if not out:
-        return []
-    try:
-        return json.loads(out)
-    except json.JSONDecodeError:
-        return []
+    return payload or []

--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -413,8 +413,8 @@ def use_gh_config_dir(gh_config_dir: Path | None) -> Iterator[None]:
 
 
 SEARCH_PULL_REQUESTS_QUERY = """
-query($query: String!, $first: Int!, $after: String) {
-  search(type: ISSUE, query: $query, first: $first, after: $after) {
+query($searchQuery: String!, $first: Int!, $after: String) {
+  search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
     pageInfo {
       hasNextPage
       endCursor
@@ -444,8 +444,8 @@ query($query: String!, $first: Int!, $after: String) {
 """
 
 SEARCH_ISSUES_QUERY = """
-query($query: String!, $first: Int!, $after: String) {
-  search(type: ISSUE, query: $query, first: $first, after: $after) {
+query($searchQuery: String!, $first: Int!, $after: String) {
+  search(type: ISSUE, query: $searchQuery, first: $first, after: $after) {
     pageInfo {
       hasNextPage
       endCursor
@@ -572,7 +572,7 @@ async def _search_items_for_org(
         args = [
             "api", "graphql",
             "-f", f"query={query}",
-            "-F", f"query={_search_query_for_org(org=org, qualifiers=qualifiers)}",
+            "-F", f"searchQuery={_search_query_for_org(org=org, qualifiers=qualifiers)}",
             "-F", f"first={page_size}",
         ]
         if after:

--- a/src/agendum/gh.py
+++ b/src/agendum/gh.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import contextmanager
 from contextvars import ContextVar
+from dataclasses import dataclass
 import json
 import logging
 import os
@@ -22,8 +23,59 @@ _TASK_GH_CONFIG_DIR: ContextVar[Path | None | object] = ContextVar(
     "agendum_task_gh_config_dir",
     default=_GH_CONFIG_DIR_UNSET,
 )
+_TASK_GH_CALL_RECORDER: ContextVar["GhCallRecorder | None"] = ContextVar(
+    "agendum_task_gh_call_recorder",
+    default=None,
+)
 DEFAULT_SEARCH_PAGE_SIZE = 50
 DEFAULT_HYDRATE_BATCH_SIZE = 25
+
+
+@dataclass
+class GhCallRecorder:
+    total_calls: int = 0
+    graphql_calls: int = 0
+    graphql_search_calls: int = 0
+    graphql_hydrate_calls: int = 0
+    rest_calls: int = 0
+    notification_calls: int = 0
+    response_bytes: int = 0
+
+    def record(self, args: tuple[str, ...], stdout: bytes) -> None:
+        self.total_calls += 1
+        self.response_bytes += len(stdout)
+
+        if args[:2] == ("api", "graphql"):
+            self.graphql_calls += 1
+            query = next(
+                (arg.split("=", 1)[1] for arg in args if arg.startswith("query=")),
+                "",
+            )
+            if "search(type: ISSUE" in query:
+                self.graphql_search_calls += 1
+            elif "node(id:" in query:
+                self.graphql_hydrate_calls += 1
+            return
+
+        if args[:2] == ("api", "notifications"):
+            self.notification_calls += 1
+
+        if args and args[0] == "api":
+            self.rest_calls += 1
+
+
+def get_gh_call_recorder() -> GhCallRecorder | None:
+    return _TASK_GH_CALL_RECORDER.get()
+
+
+@contextmanager
+def capture_gh_calls() -> Iterator[GhCallRecorder]:
+    recorder = GhCallRecorder()
+    token = _TASK_GH_CALL_RECORDER.set(recorder)
+    try:
+        yield recorder
+    finally:
+        _TASK_GH_CALL_RECORDER.reset(token)
 
 
 # ---------------------------------------------------------------------------
@@ -212,6 +264,8 @@ async def _run_gh(*args: str) -> str:
         env=env,
     )
     stdout, stderr = await proc.communicate()
+    if recorder := get_gh_call_recorder():
+        recorder.record(args, stdout)
     if proc.returncode != 0:
         log.warning("gh %s failed: %s", " ".join(args), stderr.decode().strip())
         return ""
@@ -357,124 +411,6 @@ def use_gh_config_dir(gh_config_dir: Path | None) -> Iterator[None]:
     finally:
         _TASK_GH_CONFIG_DIR.reset(token)
 
-
-# ---------------------------------------------------------------------------
-# GraphQL query for a single repo
-# ---------------------------------------------------------------------------
-
-REPO_QUERY = """
-query($owner: String!, $name: String!, $user: String!) {
-  repository(owner: $owner, name: $name) {
-    isArchived
-    openIssues: issues(
-      first: 50, states: OPEN,
-      filterBy: {assignee: $user}
-    ) {
-      nodes {
-        number title url state createdAt
-        labels(first: 10) { nodes { name } }
-        timelineItems(last: 20, itemTypes: [CONNECTED_EVENT, CROSS_REFERENCED_EVENT]) {
-          nodes {
-            ... on ConnectedEvent { subject { ... on PullRequest { url } } }
-            ... on CrossReferencedEvent { source { ... on PullRequest { url } } }
-          }
-        }
-      }
-    }
-    closedIssues: issues(
-      first: 20, states: CLOSED,
-      filterBy: {assignee: $user}
-      orderBy: {field: UPDATED_AT, direction: DESC}
-    ) {
-      nodes { number url state }
-    }
-    authoredPRs: pullRequests(
-      first: 50, states: OPEN,
-      orderBy: {field: UPDATED_AT, direction: DESC}
-    ) {
-      nodes {
-        number title url state isDraft createdAt
-        headRefName
-        author { login }
-        reviewDecision
-        reviewRequests(first: 10) { totalCount }
-        commits(last: 1) {
-          nodes {
-            commit {
-              committedDate
-            }
-          }
-        }
-        reviews(last: 20) {
-          nodes {
-            id
-            state
-            submittedAt
-            author { login }
-          }
-        }
-        reviewThreads(last: 50) {
-          nodes {
-            isResolved
-            isOutdated
-            comments(last: 20) {
-              nodes {
-                createdAt
-                pullRequestReview { id }
-                author { login }
-              }
-            }
-          }
-        }
-        labels(first: 10) { nodes { name } }
-      }
-    }
-    mergedPRs: pullRequests(
-      first: 20, states: MERGED,
-      orderBy: {field: UPDATED_AT, direction: DESC}
-    ) {
-      nodes { number url state author { login } }
-    }
-    closedPRs: pullRequests(
-      first: 20, states: CLOSED,
-      orderBy: {field: UPDATED_AT, direction: DESC}
-    ) {
-      nodes { number url state author { login } }
-    }
-  }
-}
-"""
-
-REVIEW_QUERY = """
-query($owner: String!, $name: String!, $number: Int!) {
-  repository(owner: $owner, name: $name) {
-    pullRequest(number: $number) {
-      number title url state createdAt isDraft
-      headRefName
-      author {
-        login
-        ... on User {
-          name
-        }
-      }
-      commits(last: 1) { nodes { commit { committedDate } } }
-      reviews(first: 50) {
-        nodes { author { login } submittedAt state }
-      }
-      timelineItems(last: 50, itemTypes: [REVIEW_REQUESTED_EVENT]) {
-        nodes {
-          ... on ReviewRequestedEvent {
-            createdAt
-            requestedReviewer {
-              ... on User { login }
-            }
-          }
-        }
-      }
-    }
-  }
-}
-"""
 
 SEARCH_PULL_REQUESTS_QUERY = """
 query($query: String!, $first: Int!, $after: String) {
@@ -740,36 +676,6 @@ async def _hydrate_node_batches(
     return items, ok
 
 
-async def fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-    """Fetch all relevant data for a single repo via GraphQL."""
-    payload = _load_json_payload(
-        await _run_gh(
-        "api", "graphql",
-        "-f", f"query={REPO_QUERY}",
-        "-F", f"owner={owner}",
-        "-F", f"name={name}",
-        "-F", f"user={gh_user}",
-        ),
-        context=f"repo data for {owner}/{name}",
-    )
-    return payload or {}
-
-
-async def fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
-    """Fetch review detail for a single PR to determine review status."""
-    payload = _load_json_payload(
-        await _run_gh(
-        "api", "graphql",
-        "-f", f"query={REVIEW_QUERY}",
-        "-F", f"owner={owner}",
-        "-F", f"name={name}",
-        "-F", f"number={number}",
-        ),
-        context=f"review detail for {owner}/{name}#{number}",
-    )
-    return payload or {}
-
-
 async def search_authored_prs(
     orgs: list[str],
     gh_user: str,
@@ -888,94 +794,26 @@ async def hydrate_issues(
     )
 
 
-# ---------------------------------------------------------------------------
-# Discover repos and review requests
-# ---------------------------------------------------------------------------
+async def fetch_notifications(
+    gh_user: str,
+    *,
+    since: str | None = None,
+) -> tuple[list[dict], bool]:
+    """Fetch unread GitHub notifications since an optional timestamp."""
+    del gh_user  # The notifications endpoint is scoped to the authenticated user.
 
-async def discover_repos(orgs: list[str], gh_user: str) -> set[str]:
-    """Find all repos where the user has activity, across all orgs."""
-    repos: set[str] = set()
-    for org in orgs:
-        out = await _run_gh(
-            "search", "prs",
-            "--author", gh_user,
-            "--owner", org,
-            "--state", "open",
-            "--json", "repository",
-            "--limit", "200",
-        )
-        if out:
-            for item in json.loads(out):
-                repo = item.get("repository", {})
-                name = repo.get("nameWithOwner") or repo.get("name", "")
-                if name:
-                    repos.add(name)
-
-        out = await _run_gh(
-            "search", "issues",
-            "--assignee", gh_user,
-            "--owner", org,
-            "--state", "open",
-            "--json", "repository",
-            "--limit", "200",
-        )
-        if out:
-            for item in json.loads(out):
-                repo = item.get("repository", {})
-                name = repo.get("nameWithOwner") or repo.get("name", "")
-                if name:
-                    repos.add(name)
-
-        out = await _run_gh(
-            "search", "prs",
-            "--review-requested", gh_user,
-            "--owner", org,
-            "--state", "open",
-            "--json", "repository",
-            "--limit", "200",
-        )
-        if out:
-            for item in json.loads(out):
-                repo = item.get("repository", {})
-                name = repo.get("nameWithOwner") or repo.get("name", "")
-                if name:
-                    repos.add(name)
-
-    return repos
-
-
-async def discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-    """Find all PRs where user's review is requested, across all orgs.
-
-    Returns (prs, ok) where *ok* is False if any org query failed,
-    indicating the result set may be incomplete.
-    """
-    prs: list[dict] = []
-    ok = True
-    for org in orgs:
-        out = await _run_gh(
-            "search", "prs",
-            "--review-requested", gh_user,
-            "--owner", org,
-            "--state", "open",
-            "--json", "number,title,url,repository,author",
-            "--limit", "200",
-        )
-        if out:
-            prs.extend(json.loads(out))
-        else:
-            ok = False
-    return prs, ok
-
-
-async def fetch_notifications(gh_user: str) -> list[dict]:
-    """Fetch unread GitHub notifications."""
-    payload = _load_json_payload(
-        await _run_gh(
+    args = [
         "api", "notifications",
         "--method", "GET",
         "-f", "all=false",
-        ),
+    ]
+    if since:
+        args.extend(["-f", f"since={since}"])
+
+    payload = _load_json_payload(
+        await _run_gh(*args),
         context="notifications",
     )
-    return payload or []
+    if payload is None:
+        return [], False
+    return payload, True

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -541,9 +541,7 @@ async def _run_sync_once(
         gh_user,
         since=notifications_since,
     )
-    if notifications_ok:
-        set_sync_state(db_path, _NOTIFICATIONS_SINCE_KEY, notification_fetch_started_at)
-    else:
+    if not notifications_ok:
         log.warning("Notification fetch failed — keeping previous notification cursor")
     notification_urls: list[str] = []
     for notif in notifications:
@@ -568,6 +566,8 @@ async def _run_sync_once(
         update_task(db_path, task["id"], seen=0, last_changed_at=now)
         changes += 1
         attention = True
+    if notifications_ok:
+        set_sync_state(db_path, _NOTIFICATIONS_SINCE_KEY, notification_fetch_started_at)
 
     log.info("Sync complete: %d changes, attention=%s", changes, attention)
     return changes, attention, None

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -13,7 +13,7 @@ from agendum import gh
 from agendum.config import AgendumConfig
 from agendum.db import (
     add_task,
-    find_task_by_gh_url,
+    find_tasks_by_gh_urls,
     get_active_tasks,
     update_task,
     TERMINAL_STATUSES,
@@ -27,6 +27,13 @@ class SyncResult:
     to_create: list[dict] = field(default_factory=list)
     to_update: list[dict] = field(default_factory=list)
     to_close: list[dict] = field(default_factory=list)
+
+
+@dataclass
+class CollectedSyncInputs:
+    incoming_tasks: list[dict]
+    fetched_repos: set[str]
+    review_fetch_ok: bool
 
 
 def diff_tasks(
@@ -99,35 +106,317 @@ def diff_tasks(
     return result
 
 
-async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str | None]:
-    """
-    Execute a full sync cycle.
-    Returns (changes_count, has_attention_items, error_message).
-    """
-    if not config.orgs and not config.repos:
-        log.warning("No orgs or repos configured — skipping sync")
-        return 0, False, None
-
-    with gh.use_gh_config_dir(_workspace_gh_config_dir(db_path)):
-        return await _run_sync_once(db_path, config)
+def _repo_owner(repo_full: str) -> str:
+    return repo_full.split("/", 1)[0] if "/" in repo_full else ""
 
 
-def _workspace_gh_config_dir(db_path: Path) -> Path:
-    """Map a workspace DB path to its colocated gh auth/config directory."""
-    return db_path.parent / "gh"
+def _repo_in_scope(repo_full: str, config: AgendumConfig) -> bool:
+    if not repo_full or repo_full in config.exclude_repos:
+        return False
+    if config.repos and repo_full not in config.repos:
+        return False
+    return True
 
 
-async def _run_sync_once(
-    db_path: Path,
+def _search_scope_owners(config: AgendumConfig) -> list[str]:
+    owners = {org for org in config.orgs if org}
+    owners.update(
+        owner
+        for repo in config.repos
+        if repo not in config.exclude_repos
+        if (owner := _repo_owner(repo))
+    )
+    return sorted(owners)
+
+
+def _search_item_repo(item: dict) -> str:
+    repo = item.get("repository", {})
+    return repo.get("nameWithOwner", "")
+
+
+def _covered_repos_for_search_sync(
+    existing: list[dict],
+    incoming_tasks: list[dict],
     config: AgendumConfig,
-) -> tuple[int, bool, str | None]:
-    """Execute a full sync cycle with the gh workspace already bound."""
+) -> set[str]:
+    if config.repos:
+        return {repo for repo in config.repos if repo not in config.exclude_repos}
 
-    gh_user = await gh.get_gh_username()
-    if not gh_user:
-        log.error("Could not determine GitHub username")
-        return 0, False, "gh credentials expired"
+    covered_repos = {
+        task_repo
+        for task in existing
+        if (task_repo := task.get("gh_repo"))
+        and _repo_owner(task_repo) in set(config.orgs)
+        and task_repo not in config.exclude_repos
+    }
+    covered_repos.update(
+        task_repo
+        for item in incoming_tasks
+        if (task_repo := item.get("gh_repo"))
+    )
+    return covered_repos
 
+
+def _normalize_authored_pr_task(pr: dict, gh_user: str) -> dict | None:
+    repo_full = _search_item_repo(pr)
+    author_login = (pr.get("author") or {}).get("login", "")
+    if author_login.lower() != gh_user.lower():
+        return None
+
+    reviews = pr.get("reviews", {}).get("nodes", [])
+    qualifying_reviews = [
+        review
+        for review in reviews
+        if (review.get("author") or {}).get("login", "").lower() != gh_user.lower()
+        and review.get("submittedAt")
+        and review.get("id")
+        and review.get("state") not in ("APPROVED", "CHANGES_REQUESTED", "PENDING")
+    ]
+    latest_comment_review = None
+    if qualifying_reviews:
+        latest_comment_review = max(
+            qualifying_reviews,
+            key=lambda review: review.get("submittedAt", ""),
+        )
+    last_commit_nodes = pr.get("commits", {}).get("nodes", [])
+    latest_commit_time = None
+    if last_commit_nodes:
+        latest_commit_time = (
+            last_commit_nodes[0].get("commit", {}).get("committedDate")
+        )
+    status = gh.derive_authored_pr_status(
+        is_draft=pr.get("isDraft", False),
+        review_decision=pr.get("reviewDecision"),
+        state=pr.get("state", "OPEN"),
+        has_review_requests=(pr.get("reviewRequests", {}).get("totalCount", 0) > 0),
+        latest_commit_time=latest_commit_time,
+        latest_comment_review_id=(latest_comment_review or {}).get("id"),
+        latest_comment_review_time=(latest_comment_review or {}).get("submittedAt"),
+        qualifying_reviews=qualifying_reviews,
+        author_login=author_login,
+        review_threads=pr.get("reviewThreads", {}).get("nodes", []),
+    )
+    labels = [l["name"] for l in (pr.get("labels", {}).get("nodes", []))]
+    return {
+        "title": pr["title"],
+        "source": "pr_authored",
+        "status": status,
+        "project": gh.extract_repo_short_name(repo_full),
+        "gh_repo": repo_full,
+        "gh_url": pr["url"],
+        "gh_number": pr["number"],
+        "tags": json.dumps(labels) if labels else None,
+    }
+
+
+def _normalize_review_pr_task(pr: dict, gh_user: str) -> dict:
+    reviews = pr.get("reviews", {}).get("nodes", [])
+    user_reviews = [
+        review
+        for review in reviews
+        if (review.get("author") or {}).get("login", "").lower() == gh_user.lower()
+    ]
+    user_has_reviewed = len(user_reviews) > 0
+
+    new_commits_since = False
+    re_requested_after_review = False
+    if user_has_reviewed:
+        last_review_time = max((review.get("submittedAt") or "" for review in user_reviews), default="")
+        last_commit_nodes = pr.get("commits", {}).get("nodes", [])
+        if last_commit_nodes:
+            last_commit_time = (last_commit_nodes[0].get("commit", {}).get("committedDate") or "")
+            new_commits_since = last_commit_time > last_review_time
+
+        request_events = pr.get("timelineItems", {}).get("nodes", [])
+        for event in request_events:
+            reviewer_login = ((event.get("requestedReviewer") or {}).get("login") or "")
+            if reviewer_login.lower() != gh_user.lower():
+                continue
+            created_at = event.get("createdAt") or ""
+            if created_at and created_at > last_review_time:
+                re_requested_after_review = True
+                break
+
+    status = gh.derive_review_pr_status(
+        user_has_reviewed=user_has_reviewed,
+        new_commits_since_review=new_commits_since,
+        re_requested_after_review=re_requested_after_review,
+    )
+
+    repo_full = _search_item_repo(pr)
+    author_info = pr.get("author") or {}
+    author_login = author_info.get("login", "")
+    author_name = gh.parse_author_first_name(author_info.get("name"))
+    return {
+        "title": pr.get("title", ""),
+        "source": "pr_review",
+        "status": status,
+        "project": gh.extract_repo_short_name(repo_full),
+        "gh_repo": repo_full,
+        "gh_url": pr.get("url", ""),
+        "gh_number": pr.get("number"),
+        "gh_author": author_login,
+        "gh_author_name": author_name or author_login,
+        "tags": json.dumps(["review"]),
+    }
+
+
+def _normalize_issue_task(issue: dict) -> dict:
+    repo_full = _search_item_repo(issue)
+    timeline = issue.get("timelineItems", {}).get("nodes", [])
+    has_linked_pr = any(
+        (node.get("subject") or node.get("source") or {}).get("url")
+        for node in timeline
+    )
+    status = gh.derive_issue_status(state=issue["state"], has_linked_pr=has_linked_pr)
+    labels = [l["name"] for l in (issue.get("labels", {}).get("nodes", []))]
+    return {
+        "title": issue["title"],
+        "source": "issue",
+        "status": status,
+        "project": gh.extract_repo_short_name(repo_full),
+        "gh_repo": repo_full,
+        "gh_url": issue["url"],
+        "gh_number": issue["number"],
+        "tags": json.dumps(labels) if labels else None,
+    }
+
+
+def _normalize_terminal_search_task(item: dict, *, source: str, status: str) -> dict:
+    repo_full = _search_item_repo(item)
+    labels = [l["name"] for l in (item.get("labels", {}).get("nodes", []))]
+    return {
+        "title": item.get("title", ""),
+        "source": source,
+        "status": status,
+        "project": gh.extract_repo_short_name(repo_full),
+        "gh_repo": repo_full,
+        "gh_url": item.get("url", ""),
+        "gh_number": item.get("number"),
+        "tags": json.dumps(labels) if labels else None,
+    }
+
+
+async def _collect_search_first_sync_inputs(
+    *,
+    config: AgendumConfig,
+    gh_user: str,
+    existing: list[dict],
+) -> CollectedSyncInputs:
+    incoming_tasks: list[dict] = []
+    search_owners = _search_scope_owners(config)
+
+    authored_open, authored_open_ok = await gh.search_authored_prs(search_owners, gh_user)
+    authored_merged, authored_merged_ok = await gh.search_merged_authored_prs(search_owners, gh_user)
+    authored_closed, authored_closed_ok = await gh.search_closed_authored_prs(search_owners, gh_user)
+    issue_open, issue_open_ok = await gh.search_assigned_issues(search_owners, gh_user)
+    issue_closed, issue_closed_ok = await gh.search_closed_issues(search_owners, gh_user)
+    review_open, review_search_ok = await gh.search_review_requested_prs(search_owners, gh_user)
+
+    authored_open = [item for item in authored_open if _repo_in_scope(_search_item_repo(item), config)]
+    authored_merged = [item for item in authored_merged if _repo_in_scope(_search_item_repo(item), config)]
+    authored_closed = [item for item in authored_closed if _repo_in_scope(_search_item_repo(item), config)]
+    issue_open = [item for item in issue_open if _repo_in_scope(_search_item_repo(item), config)]
+    issue_closed = [item for item in issue_closed if _repo_in_scope(_search_item_repo(item), config)]
+    review_open = [item for item in review_open if _repo_in_scope(_search_item_repo(item), config)]
+
+    authored_ids = [item["id"] for item in authored_open if item.get("id")]
+    issue_ids = [item["id"] for item in issue_open if item.get("id")]
+    review_ids = [item["id"] for item in review_open if item.get("id")]
+
+    hydrated_authored_prs: list[dict] = []
+    authored_hydrate_ok = True
+    if authored_ids:
+        hydrated_authored_prs, authored_hydrate_ok = await gh.hydrate_pull_requests(authored_ids)
+
+    hydrated_issues: list[dict] = []
+    issue_hydrate_ok = True
+    if issue_ids:
+        hydrated_issues, issue_hydrate_ok = await gh.hydrate_issues(issue_ids)
+
+    hydrated_review_prs: list[dict] = []
+    review_hydrate_ok = True
+    if review_ids:
+        hydrated_review_prs, review_hydrate_ok = await gh.hydrate_pull_requests(review_ids)
+
+    authored_by_id = {item["id"]: item for item in hydrated_authored_prs if item.get("id")}
+    issues_by_id = {item["id"]: item for item in hydrated_issues if item.get("id")}
+    review_by_id = {item["id"]: item for item in hydrated_review_prs if item.get("id")}
+
+    authored_ok = (
+        authored_open_ok
+        and authored_merged_ok
+        and authored_closed_ok
+        and authored_hydrate_ok
+        and len(authored_by_id) == len(authored_ids)
+    )
+    issues_ok = (
+        issue_open_ok
+        and issue_closed_ok
+        and issue_hydrate_ok
+        and len(issues_by_id) == len(issue_ids)
+    )
+    review_fetch_ok = (
+        review_search_ok
+        and review_hydrate_ok
+        and len(review_by_id) == len(review_ids)
+    )
+
+    for item in authored_open:
+        hydrated = authored_by_id.get(item.get("id"))
+        if not hydrated:
+            continue
+        task = _normalize_authored_pr_task(hydrated, gh_user)
+        if task:
+            incoming_tasks.append(task)
+
+    incoming_tasks.extend(
+        _normalize_terminal_search_task(item, source="pr_authored", status="merged")
+        for item in authored_merged
+    )
+    incoming_tasks.extend(
+        _normalize_terminal_search_task(item, source="pr_authored", status="closed")
+        for item in authored_closed
+    )
+
+    for item in issue_open:
+        hydrated = issues_by_id.get(item.get("id"))
+        if not hydrated:
+            continue
+        incoming_tasks.append(_normalize_issue_task(hydrated))
+
+    incoming_tasks.extend(
+        _normalize_terminal_search_task(item, source="issue", status="closed")
+        for item in issue_closed
+    )
+
+    for item in review_open:
+        hydrated = review_by_id.get(item.get("id"))
+        if not hydrated:
+            continue
+        incoming_tasks.append(_normalize_review_pr_task(hydrated, gh_user))
+
+    fetched_repos = set()
+    if authored_ok and issues_ok:
+        fetched_repos = _covered_repos_for_search_sync(existing, incoming_tasks, config)
+    else:
+        log.warning("Search-first authored/issue discovery was incomplete — skipping non-review cleanup")
+
+    if not review_fetch_ok:
+        log.warning("Review PR discovery had failures — skipping review task cleanup")
+
+    return CollectedSyncInputs(
+        incoming_tasks=incoming_tasks,
+        fetched_repos=fetched_repos,
+        review_fetch_ok=review_fetch_ok,
+    )
+
+
+async def _collect_repo_fanout_sync_inputs(
+    *,
+    config: AgendumConfig,
+    gh_user: str,
+) -> CollectedSyncInputs:
     if config.repos:
         repos = set(config.repos)
     else:
@@ -136,7 +425,7 @@ async def _run_sync_once(
 
     sem = asyncio.Semaphore(8)
     incoming_tasks: list[dict] = []
-    fetched_repos: set[str] = set()  # repos we got data from
+    fetched_repos: set[str] = set()
 
     async def fetch_one_repo(repo_full: str) -> None:
         async with sem:
@@ -151,53 +440,15 @@ async def _run_sync_once(
             short_name = gh.extract_repo_short_name(repo_full)
 
             for pr in repo_data.get("authoredPRs", {}).get("nodes", []):
-                author_login = (pr.get("author") or {}).get("login", "")
-                if author_login.lower() != gh_user.lower():
-                    continue
-                reviews = pr.get("reviews", {}).get("nodes", [])
-                qualifying_reviews = [
-                    review
-                    for review in reviews
-                    if (review.get("author") or {}).get("login", "").lower() != gh_user.lower()
-                    and review.get("submittedAt")
-                    and review.get("id")
-                    and review.get("state") not in ("APPROVED", "CHANGES_REQUESTED", "PENDING")
-                ]
-                latest_comment_review = None
-                if qualifying_reviews:
-                    latest_comment_review = max(
-                        qualifying_reviews,
-                        key=lambda review: review.get("submittedAt", ""),
-                    )
-                last_commit_nodes = pr.get("commits", {}).get("nodes", [])
-                latest_commit_time = None
-                if last_commit_nodes:
-                    latest_commit_time = (
-                        last_commit_nodes[0].get("commit", {}).get("committedDate")
-                    )
-                status = gh.derive_authored_pr_status(
-                    is_draft=pr.get("isDraft", False),
-                    review_decision=pr.get("reviewDecision"),
-                    state=pr.get("state", "OPEN"),
-                    has_review_requests=(pr.get("reviewRequests", {}).get("totalCount", 0) > 0),
-                    latest_commit_time=latest_commit_time,
-                    latest_comment_review_id=(latest_comment_review or {}).get("id"),
-                    latest_comment_review_time=(latest_comment_review or {}).get("submittedAt"),
-                    qualifying_reviews=qualifying_reviews,
-                    author_login=author_login,
-                    review_threads=pr.get("reviewThreads", {}).get("nodes", []),
+                task = _normalize_authored_pr_task(
+                    {
+                        **pr,
+                        "repository": {"nameWithOwner": repo_full},
+                    },
+                    gh_user,
                 )
-                labels = [l["name"] for l in (pr.get("labels", {}).get("nodes", []))]
-                incoming_tasks.append({
-                    "title": pr["title"],
-                    "source": "pr_authored",
-                    "status": status,
-                    "project": short_name,
-                    "gh_repo": repo_full,
-                    "gh_url": pr["url"],
-                    "gh_number": pr["number"],
-                    "tags": json.dumps(labels) if labels else None,
-                })
+                if task:
+                    incoming_tasks.append(task)
 
             for pr in repo_data.get("mergedPRs", {}).get("nodes", []):
                 author_login = (pr.get("author") or {}).get("login", "")
@@ -227,23 +478,14 @@ async def _run_sync_once(
                 })
 
             for issue in repo_data.get("openIssues", {}).get("nodes", []):
-                timeline = issue.get("timelineItems", {}).get("nodes", [])
-                has_linked_pr = any(
-                    (n.get("subject") or n.get("source") or {}).get("url")
-                    for n in timeline
+                incoming_tasks.append(
+                    _normalize_issue_task(
+                        {
+                            **issue,
+                            "repository": {"nameWithOwner": repo_full},
+                        }
+                    )
                 )
-                status = gh.derive_issue_status(state=issue["state"], has_linked_pr=has_linked_pr)
-                labels = [l["name"] for l in (issue.get("labels", {}).get("nodes", []))]
-                incoming_tasks.append({
-                    "title": issue["title"],
-                    "source": "issue",
-                    "status": status,
-                    "project": short_name,
-                    "gh_repo": repo_full,
-                    "gh_url": issue["url"],
-                    "gh_number": issue["number"],
-                    "tags": json.dumps(labels) if labels else None,
-                })
 
             for issue in repo_data.get("closedIssues", {}).get("nodes", []):
                 incoming_tasks.append({
@@ -260,92 +502,97 @@ async def _run_sync_once(
 
     review_prs, review_fetch_ok = await gh.discover_review_prs(config.orgs, gh_user)
     if config.repos and not config.orgs:
-        # Repo-only workspaces do not currently have repo-scoped review discovery,
-        # so review cleanup cannot be treated as complete.
         review_fetch_ok = False
     for pr_info in review_prs:
-        repo_info = pr_info.get("repository", {})
-        repo_full = repo_info.get("nameWithOwner", "")
-        if not repo_full or repo_full in config.exclude_repos:
-            continue
-        if config.repos and repo_full not in config.repos:
+        repo_full = (pr_info.get("repository") or {}).get("nameWithOwner", "")
+        if not _repo_in_scope(repo_full, config):
             continue
         owner, name = repo_full.split("/", 1)
         detail_data = await gh.fetch_review_detail(owner, name, pr_info["number"], gh_user)
         pr_detail = (detail_data.get("data", {}).get("repository", {}).get("pullRequest") or {})
         if not pr_detail:
+            review_fetch_ok = False
             continue
-
-        reviews = pr_detail.get("reviews", {}).get("nodes", [])
-        user_reviews = [r for r in reviews if (r.get("author") or {}).get("login", "").lower() == gh_user.lower()]
-        user_has_reviewed = len(user_reviews) > 0
-
-        new_commits_since = False
-        re_requested_after_review = False
-        if user_has_reviewed:
-            last_review_time = max((r.get("submittedAt") or "" for r in user_reviews), default="")
-            last_commit_nodes = pr_detail.get("commits", {}).get("nodes", [])
-            if last_commit_nodes:
-                last_commit_time = (last_commit_nodes[0].get("commit", {}).get("committedDate") or "")
-                new_commits_since = last_commit_time > last_review_time
-
-            request_events = pr_detail.get("timelineItems", {}).get("nodes", [])
-            for ev in request_events:
-                reviewer_login = ((ev.get("requestedReviewer") or {}).get("login") or "")
-                if reviewer_login.lower() != gh_user.lower():
-                    continue
-                created_at = ev.get("createdAt") or ""
-                if created_at and created_at > last_review_time:
-                    re_requested_after_review = True
-                    break
-
-        status = gh.derive_review_pr_status(
-            user_has_reviewed=user_has_reviewed,
-            new_commits_since_review=new_commits_since,
-            re_requested_after_review=re_requested_after_review,
+        incoming_tasks.append(
+            _normalize_review_pr_task(
+                {
+                    **pr_detail,
+                    "repository": {"nameWithOwner": repo_full},
+                },
+                gh_user,
+            )
         )
 
-        author_info = pr_detail.get("author") or {}
-        author_login = author_info.get("login", "")
-        author_name = gh.parse_author_first_name(author_info.get("name"))
-
-        incoming_tasks.append({
-            "title": pr_detail.get("title", pr_info.get("title", "")),
-            "source": "pr_review",
-            "status": status,
-            "project": gh.extract_repo_short_name(repo_full),
-            "gh_repo": repo_full,
-            "gh_url": pr_detail.get("url", pr_info.get("url", "")),
-            "gh_number": pr_detail.get("number", pr_info.get("number")),
-            "gh_author": author_login,
-            "gh_author_name": author_name or author_login,
-            "tags": json.dumps(["review"]),
-        })
-
-    # If review discovery failed, don't let the diff close review tasks
-    # from repos we didn't get review data for.
     if not review_fetch_ok:
         log.warning("Review PR discovery had failures — skipping review task cleanup")
 
-    existing = get_active_tasks(db_path)
-    diff = diff_tasks(
-        existing, incoming_tasks,
+    return CollectedSyncInputs(
+        incoming_tasks=incoming_tasks,
         fetched_repos=fetched_repos,
         review_fetch_ok=review_fetch_ok,
+    )
+
+
+async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str | None]:
+    """
+    Execute a full sync cycle.
+    Returns (changes_count, has_attention_items, error_message).
+    """
+    if not config.orgs and not config.repos:
+        log.warning("No orgs or repos configured — skipping sync")
+        return 0, False, None
+
+    with gh.use_gh_config_dir(_workspace_gh_config_dir(db_path)):
+        return await _run_sync_once(db_path, config)
+
+
+def _workspace_gh_config_dir(db_path: Path) -> Path:
+    """Map a workspace DB path to its colocated gh auth/config directory."""
+    return db_path.parent / "gh"
+
+
+async def _run_sync_once(
+    db_path: Path,
+    config: AgendumConfig,
+) -> tuple[int, bool, str | None]:
+    """Execute a full sync cycle with the gh workspace already bound."""
+
+    gh_user = await gh.get_gh_username()
+    if not gh_user:
+        log.error("Could not determine GitHub username")
+        return 0, False, "gh credentials expired"
+
+    existing = get_active_tasks(db_path)
+    collected = await _collect_search_first_sync_inputs(
+        config=config,
+        gh_user=gh_user,
+        existing=existing,
+    )
+
+    diff = diff_tasks(
+        existing,
+        collected.incoming_tasks,
+        fetched_repos=collected.fetched_repos,
+        review_fetch_ok=collected.review_fetch_ok,
     )
 
     changes = 0
     attention = False
     now = datetime.now(timezone.utc).isoformat()
+    existing_by_create_url = find_tasks_by_gh_urls(
+        db_path,
+        [item["gh_url"] for item in diff.to_create if item.get("gh_url")],
+    )
 
     for item in diff.to_create:
+        existing_task = None
+        if item.get("gh_url"):
+            existing_task = existing_by_create_url.get(item["gh_url"])
         if item.get("status") in TERMINAL_STATUSES:
-            existing_task = find_task_by_gh_url(db_path, item["gh_url"])
             if existing_task:
                 update_task(db_path, existing_task["id"], status=item["status"])
                 changes += 1
             continue
-        existing_task = find_task_by_gh_url(db_path, item["gh_url"]) if item.get("gh_url") else None
         if existing_task:
             update_fields = {
                 k: item[k] for k in ("title", "source", "status", "project",
@@ -395,25 +642,29 @@ async def _run_sync_once(
         changes += 1
 
     notifications = await gh.fetch_notifications(gh_user)
+    notification_urls: list[str] = []
     for notif in notifications:
         reason = notif.get("reason", "")
-        if reason in ("mention", "comment", "review_requested"):
-            subject = notif.get("subject", {})
-            subject_url = subject.get("url", "")
-            if subject_url and "/pulls/" in subject_url:
-                web_url = subject_url.replace("api.github.com/repos", "github.com").replace("/pulls/", "/pull/")
-                task = find_task_by_gh_url(db_path, web_url)
-                if task and task.get("seen") == 1:
-                    update_task(db_path, task["id"], seen=0, last_changed_at=now)
-                    changes += 1
-                    attention = True
-            elif subject_url and "/issues/" in subject_url:
-                web_url = subject_url.replace("api.github.com/repos", "github.com")
-                task = find_task_by_gh_url(db_path, web_url)
-                if task and task.get("seen") == 1:
-                    update_task(db_path, task["id"], seen=0, last_changed_at=now)
-                    changes += 1
-                    attention = True
+        if reason not in ("mention", "comment", "review_requested"):
+            continue
+        subject = notif.get("subject", {})
+        subject_url = subject.get("url", "")
+        if subject_url and "/pulls/" in subject_url:
+            notification_urls.append(
+                subject_url.replace("api.github.com/repos", "github.com").replace("/pulls/", "/pull/")
+            )
+        elif subject_url and "/issues/" in subject_url:
+            notification_urls.append(
+                subject_url.replace("api.github.com/repos", "github.com")
+            )
+
+    notification_tasks_by_url = find_tasks_by_gh_urls(db_path, notification_urls)
+    for web_url, task in notification_tasks_by_url.items():
+        if task.get("seen") != 1:
+            continue
+        update_task(db_path, task["id"], seen=0, last_changed_at=now)
+        changes += 1
+        attention = True
 
     log.info("Sync complete: %d changes, attention=%s", changes, attention)
     return changes, attention, None

--- a/src/agendum/syncer.py
+++ b/src/agendum/syncer.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from dataclasses import dataclass, field
@@ -15,11 +14,14 @@ from agendum.db import (
     add_task,
     find_tasks_by_gh_urls,
     get_active_tasks,
+    get_sync_state,
+    set_sync_state,
     update_task,
     TERMINAL_STATUSES,
 )
 
 log = logging.getLogger(__name__)
+_NOTIFICATIONS_SINCE_KEY = "github_notifications_since"
 
 
 @dataclass
@@ -412,127 +414,6 @@ async def _collect_search_first_sync_inputs(
     )
 
 
-async def _collect_repo_fanout_sync_inputs(
-    *,
-    config: AgendumConfig,
-    gh_user: str,
-) -> CollectedSyncInputs:
-    if config.repos:
-        repos = set(config.repos)
-    else:
-        repos = await gh.discover_repos(config.orgs, gh_user)
-    repos -= {r for r in repos if r in config.exclude_repos}
-
-    sem = asyncio.Semaphore(8)
-    incoming_tasks: list[dict] = []
-    fetched_repos: set[str] = set()
-
-    async def fetch_one_repo(repo_full: str) -> None:
-        async with sem:
-            owner, name = repo_full.split("/", 1)
-            data = await gh.fetch_repo_data(owner, name, gh_user)
-            if not data:
-                return
-            repo_data = data.get("data", {}).get("repository", {})
-            if not repo_data or repo_data.get("isArchived"):
-                return
-            fetched_repos.add(repo_full)
-            short_name = gh.extract_repo_short_name(repo_full)
-
-            for pr in repo_data.get("authoredPRs", {}).get("nodes", []):
-                task = _normalize_authored_pr_task(
-                    {
-                        **pr,
-                        "repository": {"nameWithOwner": repo_full},
-                    },
-                    gh_user,
-                )
-                if task:
-                    incoming_tasks.append(task)
-
-            for pr in repo_data.get("mergedPRs", {}).get("nodes", []):
-                author_login = (pr.get("author") or {}).get("login", "")
-                if author_login.lower() != gh_user.lower():
-                    continue
-                incoming_tasks.append({
-                    "title": "",
-                    "source": "pr_authored",
-                    "status": "merged",
-                    "gh_url": pr["url"],
-                    "gh_number": pr["number"],
-                    "project": short_name,
-                    "gh_repo": repo_full,
-                })
-            for pr in repo_data.get("closedPRs", {}).get("nodes", []):
-                author_login = (pr.get("author") or {}).get("login", "")
-                if author_login.lower() != gh_user.lower():
-                    continue
-                incoming_tasks.append({
-                    "title": "",
-                    "source": "pr_authored",
-                    "status": "closed",
-                    "gh_url": pr["url"],
-                    "gh_number": pr["number"],
-                    "project": short_name,
-                    "gh_repo": repo_full,
-                })
-
-            for issue in repo_data.get("openIssues", {}).get("nodes", []):
-                incoming_tasks.append(
-                    _normalize_issue_task(
-                        {
-                            **issue,
-                            "repository": {"nameWithOwner": repo_full},
-                        }
-                    )
-                )
-
-            for issue in repo_data.get("closedIssues", {}).get("nodes", []):
-                incoming_tasks.append({
-                    "title": "",
-                    "source": "issue",
-                    "status": "closed",
-                    "gh_url": issue["url"],
-                    "gh_number": issue["number"],
-                    "project": short_name,
-                    "gh_repo": repo_full,
-                })
-
-    await asyncio.gather(*(fetch_one_repo(r) for r in repos))
-
-    review_prs, review_fetch_ok = await gh.discover_review_prs(config.orgs, gh_user)
-    if config.repos and not config.orgs:
-        review_fetch_ok = False
-    for pr_info in review_prs:
-        repo_full = (pr_info.get("repository") or {}).get("nameWithOwner", "")
-        if not _repo_in_scope(repo_full, config):
-            continue
-        owner, name = repo_full.split("/", 1)
-        detail_data = await gh.fetch_review_detail(owner, name, pr_info["number"], gh_user)
-        pr_detail = (detail_data.get("data", {}).get("repository", {}).get("pullRequest") or {})
-        if not pr_detail:
-            review_fetch_ok = False
-            continue
-        incoming_tasks.append(
-            _normalize_review_pr_task(
-                {
-                    **pr_detail,
-                    "repository": {"nameWithOwner": repo_full},
-                },
-                gh_user,
-            )
-        )
-
-    if not review_fetch_ok:
-        log.warning("Review PR discovery had failures — skipping review task cleanup")
-
-    return CollectedSyncInputs(
-        incoming_tasks=incoming_tasks,
-        fetched_repos=fetched_repos,
-        review_fetch_ok=review_fetch_ok,
-    )
-
-
 async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str | None]:
     """
     Execute a full sync cycle.
@@ -543,7 +424,20 @@ async def run_sync(db_path: Path, config: AgendumConfig) -> tuple[int, bool, str
         return 0, False, None
 
     with gh.use_gh_config_dir(_workspace_gh_config_dir(db_path)):
-        return await _run_sync_once(db_path, config)
+        with gh.capture_gh_calls() as gh_calls:
+            result = await _run_sync_once(db_path, config)
+
+    log.info(
+        "GitHub API usage: total=%d graphql=%d search=%d hydrate=%d notifications=%d rest=%d bytes=%d",
+        gh_calls.total_calls,
+        gh_calls.graphql_calls,
+        gh_calls.graphql_search_calls,
+        gh_calls.graphql_hydrate_calls,
+        gh_calls.notification_calls,
+        gh_calls.rest_calls,
+        gh_calls.response_bytes,
+    )
+    return result
 
 
 def _workspace_gh_config_dir(db_path: Path) -> Path:
@@ -641,7 +535,16 @@ async def _run_sync_once(
         update_task(db_path, item["id"], status=terminal)
         changes += 1
 
-    notifications = await gh.fetch_notifications(gh_user)
+    notifications_since = get_sync_state(db_path, _NOTIFICATIONS_SINCE_KEY)
+    notification_fetch_started_at = datetime.now(timezone.utc).isoformat()
+    notifications, notifications_ok = await gh.fetch_notifications(
+        gh_user,
+        since=notifications_since,
+    )
+    if notifications_ok:
+        set_sync_state(db_path, _NOTIFICATIONS_SINCE_KEY, notification_fetch_started_at)
+    else:
+        log.warning("Notification fetch failed — keeping previous notification cursor")
     notification_urls: list[str] = []
     for notif in notifications:
         reason = notif.get("reason", "")

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,15 @@
 import sqlite3
 from pathlib import Path
-from agendum.db import init_db, add_task, get_active_tasks, update_task, remove_task
+
+from agendum.db import (
+    add_task,
+    get_active_tasks,
+    get_sync_state,
+    init_db,
+    remove_task,
+    set_sync_state,
+    update_task,
+)
 
 
 def test_init_db_creates_tables(tmp_db: Path) -> None:
@@ -10,6 +19,7 @@ def test_init_db_creates_tables(tmp_db: Path) -> None:
     tables = {row[0] for row in cursor.fetchall()}
     conn.close()
     assert "tasks" in tables
+    assert "sync_state" in tables
 
 
 def test_init_db_is_idempotent(tmp_db: Path) -> None:
@@ -134,3 +144,12 @@ def test_find_tasks_by_gh_urls_returns_matches_only(tmp_db: Path) -> None:
     assert set(tasks) == {first_url, second_url}
     assert tasks[first_url]["title"] == "PR 1"
     assert tasks[second_url]["title"] == "Issue 2"
+
+
+def test_set_sync_state_upserts_value(tmp_db: Path) -> None:
+    init_db(tmp_db)
+
+    set_sync_state(tmp_db, "github_notifications_since", "2026-04-24T12:00:00+00:00")
+    set_sync_state(tmp_db, "github_notifications_since", "2026-04-24T12:05:00+00:00")
+
+    assert get_sync_state(tmp_db, "github_notifications_since") == "2026-04-24T12:05:00+00:00"

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -115,3 +115,22 @@ def test_find_task_by_gh_url(tmp_db: Path) -> None:
     assert task is not None
     assert task["title"] == "PR 1"
     assert find_task_by_gh_url(tmp_db, "https://nonexistent") is None
+
+
+def test_find_tasks_by_gh_urls_returns_matches_only(tmp_db: Path) -> None:
+    from agendum.db import find_tasks_by_gh_urls
+
+    init_db(tmp_db)
+    first_url = "https://github.com/org/repo/pull/1"
+    second_url = "https://github.com/org/repo/issues/2"
+    add_task(tmp_db, title="PR 1", source="pr_authored", status="open", gh_url=first_url)
+    add_task(tmp_db, title="Issue 2", source="issue", status="open", gh_url=second_url)
+
+    tasks = find_tasks_by_gh_urls(
+        tmp_db,
+        [first_url, "https://github.com/org/repo/pull/999", second_url],
+    )
+
+    assert set(tasks) == {first_url, second_url}
+    assert tasks[first_url]["title"] == "PR 1"
+    assert tasks[second_url]["title"] == "Issue 2"

--- a/tests/test_db_edge_cases.py
+++ b/tests/test_db_edge_cases.py
@@ -4,7 +4,14 @@ from pathlib import Path
 
 import pytest
 
-from agendum.db import add_task, get_active_tasks, init_db, mark_all_seen, update_task
+from agendum.db import (
+    add_task,
+    find_tasks_by_gh_urls,
+    get_active_tasks,
+    init_db,
+    mark_all_seen,
+    update_task,
+)
 
 
 def test_mark_all_seen(tmp_db: Path) -> None:
@@ -68,3 +75,30 @@ def test_get_active_tasks_ordering(tmp_db: Path) -> None:
     tasks = get_active_tasks(tmp_db)
     assert tasks[0]["title"] == "Unseen PR"
     assert tasks[1]["title"] == "Seen PR"
+
+
+def test_find_tasks_by_gh_urls_dedupes_duplicate_inputs(tmp_db: Path) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/org/repo/pull/1"
+    add_task(tmp_db, title="PR 1", source="pr_authored", status="open", gh_url=url)
+
+    tasks = find_tasks_by_gh_urls(tmp_db, [url, url, url])
+
+    assert list(tasks) == [url]
+    assert tasks[url]["title"] == "PR 1"
+
+
+def test_find_tasks_by_gh_urls_includes_terminal_rows(tmp_db: Path) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/org/repo/pull/9"
+    add_task(tmp_db, title="Merged PR", source="pr_authored", status="merged", gh_url=url)
+
+    tasks = find_tasks_by_gh_urls(tmp_db, [url])
+
+    assert tasks[url]["status"] == "merged"
+
+
+def test_find_tasks_by_gh_urls_empty_input_returns_empty_mapping(tmp_db: Path) -> None:
+    init_db(tmp_db)
+
+    assert find_tasks_by_gh_urls(tmp_db, []) == {}

--- a/tests/test_db_edge_cases.py
+++ b/tests/test_db_edge_cases.py
@@ -8,8 +8,10 @@ from agendum.db import (
     add_task,
     find_tasks_by_gh_urls,
     get_active_tasks,
+    get_sync_state,
     init_db,
     mark_all_seen,
+    set_sync_state,
     update_task,
 )
 
@@ -102,3 +104,28 @@ def test_find_tasks_by_gh_urls_empty_input_returns_empty_mapping(tmp_db: Path) -
     init_db(tmp_db)
 
     assert find_tasks_by_gh_urls(tmp_db, []) == {}
+
+
+def test_get_sync_state_returns_none_for_missing_key(tmp_db: Path) -> None:
+    init_db(tmp_db)
+
+    assert get_sync_state(tmp_db, "missing") is None
+
+
+def test_set_sync_state_tracks_updated_at(tmp_db: Path) -> None:
+    init_db(tmp_db)
+
+    set_sync_state(tmp_db, "github_notifications_since", "2026-04-24T12:00:00+00:00")
+
+    import sqlite3
+
+    conn = sqlite3.connect(tmp_db)
+    row = conn.execute(
+        "SELECT value, updated_at FROM sync_state WHERE key = ?",
+        ("github_notifications_since",),
+    ).fetchone()
+    conn.close()
+
+    assert row is not None
+    assert row[0] == "2026-04-24T12:00:00+00:00"
+    assert row[1] is not None

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -1,5 +1,7 @@
+import inspect
 import json
 from pathlib import Path
+import re
 from types import SimpleNamespace
 import pytest
 
@@ -12,6 +14,7 @@ from agendum.gh import (
     derive_review_pr_status,
     derive_issue_status,
     fetch_review_detail,
+    hydrate_pull_requests,
     get_gh_config_dir,
     _run_gh,
     parse_author_first_name,
@@ -21,6 +24,19 @@ from agendum.gh import (
     set_gh_config_dir,
     use_gh_config_dir,
 )
+
+
+async def call_gh_primitive(name: str, *args, **kwargs):
+    from agendum import gh
+
+    result = getattr(gh, name)(*args, **kwargs)
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+def query_arg(args: tuple[str, ...]) -> str:
+    return next(arg.split("=", 1)[1] for arg in args if arg.startswith("query="))
 
 
 def authored_pr_status_with_review_feedback(**overrides: object) -> str:
@@ -615,3 +631,167 @@ async def test_fetch_review_detail_uses_valid_author_name_query(monkeypatch) -> 
     assert "-F" in call
     assert "user=current-user" not in call
     assert "... on User" in query_arg
+
+
+@pytest.mark.asyncio
+async def test_hydrate_pull_requests_uses_node_alias_query(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run_gh(*args: str) -> str:
+        calls.append(args)
+        return json.dumps(
+            {
+                "data": {
+                    "n0": {"id": "PR_node_1", "title": "One"},
+                    "n1": {"id": "PR_node_2", "title": "Two"},
+                },
+            }
+        )
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    result, ok = await hydrate_pull_requests(["PR_node_1", "PR_node_2"])
+
+    assert ok is True
+    assert [item["id"] for item in result] == ["PR_node_1", "PR_node_2"]
+    query_arg = next(arg for arg in calls[0] if arg.startswith("query="))
+    assert "n0: node(id: \"PR_node_1\")" in query_arg
+    assert "n1: node(id: \"PR_node_2\")" in query_arg
+    assert "... on PullRequest" in query_arg
+
+
+@pytest.mark.asyncio
+async def test_search_authored_prs_paginates_and_dedupes_by_node_id(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    responses = [
+        {
+            "data": {
+                "search": {
+                    "pageInfo": {
+                        "hasNextPage": True,
+                        "endCursor": "CURSOR_A",
+                    },
+                    "nodes": [
+                        {"id": "PR_1", "number": 1, "title": "One"},
+                        {"id": "PR_2", "number": 2, "title": "Two"},
+                    ],
+                },
+            },
+        },
+        {
+            "data": {
+                "search": {
+                    "pageInfo": {
+                        "hasNextPage": False,
+                        "endCursor": None,
+                    },
+                    "nodes": [
+                        {"id": "PR_2", "number": 2, "title": "Two"},
+                        {"id": "PR_3", "number": 3, "title": "Three"},
+                    ],
+                },
+            },
+        },
+        {
+            "data": {
+                "search": {
+                    "pageInfo": {
+                        "hasNextPage": False,
+                        "endCursor": None,
+                    },
+                    "nodes": [
+                        {"id": "PR_3", "number": 3, "title": "Three"},
+                    ],
+                },
+            },
+        },
+    ]
+
+    async def fake_run_gh(*args: str) -> str:
+        calls.append(args)
+        return json.dumps(responses.pop(0))
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    prs, ok = await call_gh_primitive("search_authored_prs", ["org-a", "org-b"], "dan", page_size=2)
+
+    assert ok is True
+    assert [pr["id"] for pr in prs] == ["PR_1", "PR_2", "PR_3"]
+    assert len(calls) == 3
+    assert "pageInfo" in query_arg(calls[0])
+    assert "CURSOR_A" in " ".join(calls[1])
+
+
+@pytest.mark.asyncio
+async def test_search_assigned_issues_uses_issue_search_query(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run_gh(*args: str) -> str:
+        calls.append(args)
+        return json.dumps(
+            {
+                "data": {
+                    "search": {
+                        "pageInfo": {
+                            "hasNextPage": False,
+                            "endCursor": None,
+                        },
+                        "nodes": [
+                            {"id": "ISSUE_1", "number": 11, "title": "Assigned"},
+                        ],
+                    },
+                },
+            }
+        )
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    issues, ok = await call_gh_primitive("search_assigned_issues", ["org-a"], "dan", page_size=7)
+
+    assert ok is True
+    assert [issue["id"] for issue in issues] == ["ISSUE_1"]
+    assert "search(type: ISSUE" in query_arg(calls[0])
+
+
+@pytest.mark.asyncio
+async def test_hydrate_pull_requests_batches_and_skips_nulls(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+    response_nodes = [
+        [
+            {"id": "PR_1", "number": 1, "title": "One"},
+            None,
+        ],
+        [
+            {"id": "PR_3", "number": 3, "title": "Three"},
+        ],
+    ]
+
+    async def fake_run_gh(*args: str) -> str:
+        calls.append(args)
+        aliases = re.findall(r"(\w+)\s*:\s*node\(", query_arg(args))
+        nodes = response_nodes[len(calls) - 1]
+        return json.dumps(
+            {
+                "data": {
+                    alias: node
+                    for alias, node in zip(aliases, nodes)
+                },
+            }
+        )
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    prs, ok = await call_gh_primitive("hydrate_pull_requests", ["PR_1", "PR_2", "PR_3"], batch_size=2)
+
+    assert ok is True
+    assert [pr["id"] for pr in prs] == ["PR_1", "PR_3"]
+    assert len(calls) == 2
+    assert len(re.findall(r"(\w+)\s*:\s*node\(", query_arg(calls[0]))) == 2

--- a/tests/test_gh.py
+++ b/tests/test_gh.py
@@ -8,12 +8,12 @@ import pytest
 from agendum.gh import (
     auth_status,
     auth_login,
+    capture_gh_calls,
     recover_gh_auth,
     default_gh_config_dir,
     derive_authored_pr_status,
     derive_review_pr_status,
     derive_issue_status,
-    fetch_review_detail,
     hydrate_pull_requests,
     get_gh_config_dir,
     _run_gh,
@@ -598,39 +598,54 @@ def test_extract_repo_short_name() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fetch_review_detail_uses_valid_author_name_query(monkeypatch) -> None:
-    calls: list[tuple[str, ...]] = []
+async def test_capture_gh_calls_classifies_search_hydrate_and_notifications(monkeypatch) -> None:
+    outputs = iter(
+        [
+            b'{"data":{"search":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}',
+            b'{"data":{"n0":{"id":"PR_1"}}}',
+            b"[]",
+            b"author\n",
+        ]
+    )
 
-    async def fake_run_gh(*args: str) -> str:
-        calls.append(args)
-        return json.dumps(
-            {
-                "data": {
-                    "repository": {
-                        "pullRequest": {
-                            "author": {
-                                "login": "reviewer",
-                                "name": "Review Person",
-                            },
-                        },
-                    },
-                },
-            }
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, stdout: bytes):
+            self.stdout = stdout
+
+        async def communicate(self):
+            return self.stdout, b""
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        del args, kwargs
+        return FakeProcess(next(outputs))
+
+    monkeypatch.setattr("agendum.gh.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+
+    with capture_gh_calls() as recorder:
+        await _run_gh(
+            "api",
+            "graphql",
+            "-f",
+            "query=query { search(type: ISSUE, query: \"org:example is:open\", first: 50) { nodes { ... on Issue { id } } pageInfo { hasNextPage endCursor } } }",
         )
+        await _run_gh(
+            "api",
+            "graphql",
+            "-f",
+            'query=query { n0: node(id: "PR_1") { ... on PullRequest { id } } }',
+        )
+        await _run_gh("api", "notifications", "--method", "GET", "-f", "all=false")
+        await _run_gh("api", "user", "--jq", ".login")
 
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
-
-    result = await fetch_review_detail("example-org", "example-repo", 34, "current-user")
-
-    assert result["data"]["repository"]["pullRequest"]["author"]["name"] == "Review Person"
-    call = calls[0]
-    query_arg = next(arg for arg in call if arg.startswith("query="))
-    assert "$user" not in query_arg
-    assert "-F" in call
-    assert "user=current-user" not in call
-    assert "... on User" in query_arg
+    assert recorder.total_calls == 4
+    assert recorder.graphql_calls == 2
+    assert recorder.graphql_search_calls == 1
+    assert recorder.graphql_hydrate_calls == 1
+    assert recorder.notification_calls == 1
+    assert recorder.rest_calls == 2
+    assert recorder.response_bytes > 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_gh_edge_cases.py
+++ b/tests/test_gh_edge_cases.py
@@ -1,10 +1,21 @@
 """Tests for gh module functions that interact with the gh CLI."""
 
 import json
+from typing import Any
 
 import pytest
 
-from agendum.gh import discover_repos, discover_review_prs, fetch_notifications, fetch_repo_data
+from agendum.gh import (
+    discover_repos,
+    discover_review_prs,
+    fetch_notifications,
+    fetch_repo_data,
+    hydrate_issues,
+    hydrate_pull_requests,
+    search_assigned_issues,
+    search_authored_prs,
+    search_review_requested_prs,
+)
 
 
 async def test_discover_repos_aggregates_across_searches(monkeypatch) -> None:
@@ -101,3 +112,173 @@ async def test_fetch_repo_data_empty_response(monkeypatch) -> None:
     monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
 
     assert await fetch_repo_data("org", "repo", "user") == {}
+
+
+def _search_payload(
+    nodes: list[dict[str, Any]],
+    *,
+    has_next_page: bool = False,
+    end_cursor: str | None = None,
+) -> str:
+    return json.dumps(
+        {
+            "data": {
+                "search": {
+                    "nodes": nodes,
+                    "pageInfo": {
+                        "hasNextPage": has_next_page,
+                        "endCursor": end_cursor,
+                    },
+                },
+            },
+        }
+    )
+
+
+def _query_value(args: tuple[str, ...], name: str) -> str | None:
+    for index, arg in enumerate(args):
+        if arg == "-F" and index + 1 < len(args) and args[index + 1].startswith(f"{name}="):
+            return args[index + 1]
+    return None
+
+
+async def test_search_authored_prs_paginates_and_dedupes(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run_gh(*args: str) -> str:
+        calls.append(args)
+        query_value = _query_value(args, "query")
+        after_value = _query_value(args, "after")
+
+        if query_value == "query=org:org-a is:open is:pr author:user" and after_value is None:
+            return _search_payload(
+                [{"id": "PR_1", "title": "one"}, {"id": "PR_2", "title": "two"}],
+                has_next_page=True,
+                end_cursor="cursor-a",
+            )
+        if query_value == "query=org:org-a is:open is:pr author:user" and after_value == "after=cursor-a":
+            return _search_payload(
+                [{"id": "PR_2", "title": "dup"}, {"id": "PR_3", "title": "three"}]
+            )
+        if query_value == "query=org:org-b is:open is:pr author:user":
+            return _search_payload(
+                [{"id": "PR_3", "title": "dup"}, {"id": "PR_4", "title": "four"}]
+            )
+        raise AssertionError(f"Unexpected gh call: {args}")
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    items, ok = await search_authored_prs(["org-a", "org-b"], "user", page_size=2)
+
+    assert ok is True
+    assert [item["id"] for item in items] == ["PR_1", "PR_2", "PR_3", "PR_4"]
+    query_arg = next(arg for arg in calls[0] if arg.startswith("query="))
+    assert "search(type: ISSUE" in query_arg
+
+
+async def test_search_assigned_issues_marks_invalid_page_incomplete(monkeypatch) -> None:
+    async def fake_run_gh(*args: str) -> str:
+        query_value = _query_value(args, "query")
+        if query_value == "query=org:org-a is:open is:issue assignee:user":
+            return _search_payload([{"id": "ISSUE_1", "title": "one"}])
+        if query_value == "query=org:org-b is:open is:issue assignee:user":
+            return "not json"
+        raise AssertionError(f"Unexpected gh call: {args}")
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    items, ok = await search_assigned_issues(["org-a", "org-b"], "user")
+
+    assert ok is False
+    assert [item["id"] for item in items] == ["ISSUE_1"]
+
+
+async def test_search_review_requested_prs_marks_empty_page_incomplete(monkeypatch) -> None:
+    async def fake_run_gh(*args: str) -> str:
+        return ""
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    items, ok = await search_review_requested_prs(["org"], "reviewer")
+
+    assert items == []
+    assert ok is False
+
+
+@pytest.mark.parametrize(
+    ("func", "node_ids"),
+    [
+        (hydrate_pull_requests, ["PR_1", "PR_2"]),
+        (hydrate_issues, ["ISSUE_1", "ISSUE_2"]),
+    ],
+)
+async def test_hydration_primitives_return_not_ok_on_invalid_json(
+    monkeypatch,
+    func,
+    node_ids: list[str],
+) -> None:
+    async def fake_run_gh(*args: str) -> str:
+        return "not json"
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    items, ok = await func(node_ids, batch_size=1)
+
+    assert items == []
+    assert ok is False
+
+
+async def test_hydrate_pull_requests_batches_and_skips_null_nodes(monkeypatch) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    async def fake_run_gh(*args: str) -> str:
+        calls.append(args)
+        query_arg = next(arg for arg in args if arg.startswith("query="))
+        if "PR_1" in query_arg:
+            return json.dumps(
+                {
+                    "data": {
+                        "n0": {"id": "PR_1", "title": "one"},
+                        "n1": None,
+                    },
+                }
+            )
+        return json.dumps({"data": {"n0": {"id": "PR_3", "title": "three"}}})
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    items, ok = await hydrate_pull_requests(["PR_1", "PR_2", "PR_3"], batch_size=2)
+
+    assert ok is True
+    assert [item["id"] for item in items] == ["PR_1", "PR_3"]
+    assert len(calls) == 2
+
+
+async def test_hydrate_issues_returns_not_ok_on_failed_batch_after_partial_success(monkeypatch) -> None:
+    calls = 0
+
+    async def fake_run_gh(*args: str) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return json.dumps({"data": {"n0": {"id": "ISSUE_1", "number": 1}}})
+        return ""
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+
+    items, ok = await hydrate_issues(["ISSUE_1", "ISSUE_2"], batch_size=1)
+
+    assert [item["id"] for item in items] == ["ISSUE_1"]
+    assert ok is False

--- a/tests/test_gh_edge_cases.py
+++ b/tests/test_gh_edge_cases.py
@@ -99,20 +99,20 @@ async def test_search_authored_prs_paginates_and_dedupes(monkeypatch) -> None:
 
     async def fake_run_gh(*args: str) -> str:
         calls.append(args)
-        query_value = _query_value(args, "query")
+        search_query_value = _query_value(args, "searchQuery")
         after_value = _query_value(args, "after")
 
-        if query_value == "query=org:org-a is:open is:pr author:user" and after_value is None:
+        if search_query_value == "searchQuery=org:org-a is:open is:pr author:user" and after_value is None:
             return _search_payload(
                 [{"id": "PR_1", "title": "one"}, {"id": "PR_2", "title": "two"}],
                 has_next_page=True,
                 end_cursor="cursor-a",
             )
-        if query_value == "query=org:org-a is:open is:pr author:user" and after_value == "after=cursor-a":
+        if search_query_value == "searchQuery=org:org-a is:open is:pr author:user" and after_value == "after=cursor-a":
             return _search_payload(
                 [{"id": "PR_2", "title": "dup"}, {"id": "PR_3", "title": "three"}]
             )
-        if query_value == "query=org:org-b is:open is:pr author:user":
+        if search_query_value == "searchQuery=org:org-b is:open is:pr author:user":
             return _search_payload(
                 [{"id": "PR_3", "title": "dup"}, {"id": "PR_4", "title": "four"}]
             )
@@ -128,14 +128,15 @@ async def test_search_authored_prs_paginates_and_dedupes(monkeypatch) -> None:
     assert [item["id"] for item in items] == ["PR_1", "PR_2", "PR_3", "PR_4"]
     query_arg = next(arg for arg in calls[0] if arg.startswith("query="))
     assert "search(type: ISSUE" in query_arg
+    assert _query_value(calls[0], "searchQuery") == "searchQuery=org:org-a is:open is:pr author:user"
 
 
 async def test_search_assigned_issues_marks_invalid_page_incomplete(monkeypatch) -> None:
     async def fake_run_gh(*args: str) -> str:
-        query_value = _query_value(args, "query")
-        if query_value == "query=org:org-a is:open is:issue assignee:user":
+        search_query_value = _query_value(args, "searchQuery")
+        if search_query_value == "searchQuery=org:org-a is:open is:issue assignee:user":
             return _search_payload([{"id": "ISSUE_1", "title": "one"}])
-        if query_value == "query=org:org-b is:open is:issue assignee:user":
+        if search_query_value == "searchQuery=org:org-b is:open is:issue assignee:user":
             return "not json"
         raise AssertionError(f"Unexpected gh call: {args}")
 

--- a/tests/test_gh_edge_cases.py
+++ b/tests/test_gh_edge_cases.py
@@ -6,72 +6,13 @@ from typing import Any
 import pytest
 
 from agendum.gh import (
-    discover_repos,
-    discover_review_prs,
     fetch_notifications,
-    fetch_repo_data,
     hydrate_issues,
     hydrate_pull_requests,
     search_assigned_issues,
     search_authored_prs,
     search_review_requested_prs,
 )
-
-
-async def test_discover_repos_aggregates_across_searches(monkeypatch) -> None:
-    call_log = []
-
-    async def fake_run_gh(*args: str) -> str:
-        call_log.append(args)
-        # Return different repos for each search type based on args
-        if "--author" in args:
-            return json.dumps([
-                {"repository": {"nameWithOwner": "org/authored-repo"}},
-            ])
-        if "--assignee" in args:
-            return json.dumps([
-                {"repository": {"nameWithOwner": "org/assigned-repo"}},
-            ])
-        if "--review-requested" in args:
-            return json.dumps([
-                {"repository": {"nameWithOwner": "org/review-repo"}},
-            ])
-        return "[]"
-
-    from agendum import gh
-    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
-
-    repos = await discover_repos(["org"], "user")
-
-    assert repos == {"org/authored-repo", "org/assigned-repo", "org/review-repo"}
-
-
-async def test_discover_repos_handles_empty_output(monkeypatch) -> None:
-    async def fake_run_gh(*args: str) -> str:
-        return ""
-
-    from agendum import gh
-    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
-
-    repos = await discover_repos(["org"], "user")
-    assert repos == set()
-
-
-async def test_discover_review_prs_across_orgs(monkeypatch) -> None:
-    async def fake_run_gh(*args: str) -> str:
-        # The org name is passed via --owner
-        owner_idx = args.index("--owner") + 1 if "--owner" in args else -1
-        org = args[owner_idx] if owner_idx > 0 else "unknown"
-        return json.dumps([
-            {"number": 1, "title": f"PR from {org}", "url": f"https://github.com/{org}/repo/pull/1",
-             "repository": {"nameWithOwner": f"{org}/repo"}, "author": {"login": "dev"}},
-        ])
-
-    from agendum import gh
-    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
-
-    prs = await discover_review_prs(["org-a", "org-b"], "reviewer")
-    assert len(prs) == 2
 
 
 async def test_fetch_notifications_empty_response(monkeypatch) -> None:
@@ -81,7 +22,7 @@ async def test_fetch_notifications_empty_response(monkeypatch) -> None:
     from agendum import gh
     monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
 
-    assert await fetch_notifications("user") == []
+    assert await fetch_notifications("user") == ([], False)
 
 
 async def test_fetch_notifications_invalid_json(monkeypatch) -> None:
@@ -91,27 +32,38 @@ async def test_fetch_notifications_invalid_json(monkeypatch) -> None:
     from agendum import gh
     monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
 
-    assert await fetch_notifications("user") == []
+    assert await fetch_notifications("user") == ([], False)
 
 
-async def test_fetch_repo_data_invalid_json(monkeypatch) -> None:
+async def test_fetch_notifications_forwards_since(monkeypatch) -> None:
+    call_log: list[tuple[str, ...]] = []
+
     async def fake_run_gh(*args: str) -> str:
-        return "not json"
+        call_log.append(args)
+        return "[]"
 
     from agendum import gh
     monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
 
-    assert await fetch_repo_data("org", "repo", "user") == {}
+    notifications, ok = await fetch_notifications(
+        "user",
+        since="2026-04-24T12:00:00+00:00",
+    )
 
-
-async def test_fetch_repo_data_empty_response(monkeypatch) -> None:
-    async def fake_run_gh(*args: str) -> str:
-        return ""
-
-    from agendum import gh
-    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
-
-    assert await fetch_repo_data("org", "repo", "user") == {}
+    assert notifications == []
+    assert ok is True
+    assert call_log == [
+        (
+            "api",
+            "notifications",
+            "--method",
+            "GET",
+            "-f",
+            "all=false",
+            "-f",
+            "since=2026-04-24T12:00:00+00:00",
+        ),
+    ]
 
 
 def _search_payload(

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1,10 +1,11 @@
 import json
+import logging
 from pathlib import Path
 
 import pytest
 
 from agendum.config import AgendumConfig
-from agendum.db import add_task, find_task_by_gh_url, get_active_tasks, init_db
+from agendum.db import add_task, find_task_by_gh_url, get_active_tasks, get_sync_state, init_db
 from agendum.syncer import diff_tasks, run_sync
 
 
@@ -155,9 +156,14 @@ def install_repo_only_search_first_mocks(
     async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
         return [issues_by_id[node_id] for node_id in node_ids if node_id in issues_by_id], True
 
-    async def fake_fetch_notifications(seen_user: str) -> list[dict]:
+    async def fake_fetch_notifications(
+        seen_user: str,
+        *,
+        since: str | None = None,
+    ) -> tuple[list[dict], bool]:
         assert seen_user == gh_user
-        return list(notifications or [])
+        del since
+        return list(notifications or []), True
 
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
     monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
@@ -322,12 +328,6 @@ async def test_run_sync_org_sync_uses_search_first_helpers(tmp_db: Path, monkeyp
 
     pr_hydrate_calls: list[tuple[str, ...]] = []
     issue_hydrate_calls: list[tuple[str, ...]] = []
-    legacy_calls = {
-        "discover_repos": 0,
-        "fetch_repo_data": 0,
-        "discover_review_prs": 0,
-        "fetch_review_detail": 0,
-    }
 
     authored_url = "https://github.com/org/authored-repo/pull/1"
     issue_url = "https://github.com/org/issue-repo/issues/2"
@@ -414,26 +414,13 @@ async def test_run_sync_org_sync_uses_search_first_helpers(tmp_db: Path, monkeyp
         issue_hydrate_calls.append(tuple(node_ids))
         return [issue for node_id in node_ids if node_id == "ISSUE_1"], True
 
-    async def fake_discover_repos(orgs: list[str], gh_user: str) -> set[str]:
-        legacy_calls["discover_repos"] += 1
-        return {"org/legacy"}
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        legacy_calls["fetch_repo_data"] += 1
-        return {}
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        legacy_calls["discover_review_prs"] += 1
+    async def fake_fetch_notifications(
+        gh_user: str,
+        *,
+        since: str | None = None,
+    ) -> tuple[list[dict], bool]:
+        del gh_user, since
         return [], True
-
-    async def fake_fetch_review_detail(
-        owner: str, name: str, number: int, gh_user: str,
-    ) -> dict:
-        legacy_calls["fetch_review_detail"] += 1
-        return {}
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
 
     from agendum import gh
 
@@ -446,10 +433,6 @@ async def test_run_sync_org_sync_uses_search_first_helpers(tmp_db: Path, monkeyp
     monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
     monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
     monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
-    monkeypatch.setattr(gh, "discover_repos", fake_discover_repos)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_review_detail", fake_fetch_review_detail)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(tmp_db, AgendumConfig(orgs=["org"]))
@@ -462,12 +445,6 @@ async def test_run_sync_org_sync_uses_search_first_helpers(tmp_db: Path, monkeyp
         "PR_REVIEW_1",
     }
     assert issue_hydrate_calls == [("ISSUE_1",)]
-    assert legacy_calls == {
-        "discover_repos": 0,
-        "fetch_repo_data": 0,
-        "discover_review_prs": 0,
-        "fetch_review_detail": 0,
-    }
 
     authored_task = find_task_by_gh_url(tmp_db, authored_url)
     assert authored_task is not None
@@ -515,6 +492,7 @@ async def test_run_sync_reports_missing_gh_auth(tmp_db: Path, monkeypatch) -> No
 async def test_run_sync_keeps_workspace_gh_config_dir_when_global_changes(
     tmp_db: Path,
     monkeypatch,
+    caplog,
 ) -> None:
     init_db(tmp_db)
 
@@ -525,29 +503,40 @@ async def test_run_sync_keeps_workspace_gh_config_dir_when_global_changes(
     observed_gh_dirs: list[Path | None] = []
     switched = False
 
-    async def fake_run_gh(*args: str) -> str:
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, stdout: bytes):
+            self.stdout = stdout
+
+        async def communicate(self):
+            return self.stdout, b""
+
+    async def fake_create_subprocess_exec(*args: str, **kwargs):
         nonlocal switched
         observed_gh_dirs.append(gh.get_gh_config_dir())
         if not switched:
             gh.set_gh_config_dir(switched_gh_dir)
             switched = True
 
-        if args == ("api", "user", "--jq", ".login"):
-            return "author\n"
-        if args[:2] == ("api", "graphql"):
-            return json.dumps({
+        gh_args = args[1:]
+        if gh_args == ("api", "user", "--jq", ".login"):
+            return FakeProcess(b"author\n")
+        if gh_args[:2] == ("api", "graphql"):
+            return FakeProcess(json.dumps({
                 "data": {
                     "search": {
                         "pageInfo": {"hasNextPage": False, "endCursor": None},
                         "nodes": [],
                     },
                 },
-            })
-        if args[:2] == ("api", "notifications"):
-            return "[]"
-        raise AssertionError(f"Unexpected gh call: {args}")
+            }).encode())
+        if gh_args[:2] == ("api", "notifications"):
+            return FakeProcess(b"[]")
+        raise AssertionError(f"Unexpected gh call: {gh_args}")
 
-    monkeypatch.setattr(gh, "_run_gh", fake_run_gh)
+    monkeypatch.setattr("agendum.gh.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+    caplog.set_level(logging.INFO)
 
     gh.set_gh_config_dir(workspace_gh_dir)
     try:
@@ -563,6 +552,90 @@ async def test_run_sync_keeps_workspace_gh_config_dir_when_global_changes(
     assert error is None
     assert observed_gh_dirs
     assert all(path == workspace_gh_dir for path in observed_gh_dirs)
+    assert any(
+        "GitHub API usage: total=8 graphql=6 search=6 hydrate=0 notifications=1 rest=2"
+        in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_sync_persists_incremental_notification_cursor(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    init_db(tmp_db)
+    repo = "example-org/example-repo"
+    observed_since: list[str | None] = []
+
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="reviewer",
+    )
+
+    from agendum import gh
+
+    async def fake_fetch_notifications(
+        gh_user: str,
+        *,
+        since: str | None = None,
+    ) -> tuple[list[dict], bool]:
+        assert gh_user == "reviewer"
+        observed_since.append(since)
+        return [], True
+
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    first_changes, _, first_error = await run_sync(tmp_db, AgendumConfig(repos=[repo]))
+    first_cursor = get_sync_state(tmp_db, "github_notifications_since")
+
+    second_changes, _, second_error = await run_sync(tmp_db, AgendumConfig(repos=[repo]))
+
+    assert first_changes == 0
+    assert second_changes == 0
+    assert first_error is None
+    assert second_error is None
+    assert first_cursor is not None
+    assert observed_since == [None, first_cursor]
+
+
+@pytest.mark.asyncio
+async def test_run_sync_preserves_notification_cursor_when_fetch_fails(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    init_db(tmp_db)
+    repo = "example-org/example-repo"
+    original_cursor = "2026-04-24T12:00:00+00:00"
+
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="reviewer",
+    )
+    from agendum import gh
+    from agendum.db import set_sync_state
+
+    set_sync_state(tmp_db, "github_notifications_since", original_cursor)
+
+    async def fake_fetch_notifications(
+        gh_user: str,
+        *,
+        since: str | None = None,
+    ) -> tuple[list[dict], bool]:
+        assert gh_user == "reviewer"
+        assert since == original_cursor
+        return [], False
+
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(repos=[repo]))
+
+    assert changes == 0
+    assert attention is False
+    assert error is None
+    assert get_sync_state(tmp_db, "github_notifications_since") == original_cursor
 
 
 @pytest.mark.asyncio

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from pathlib import Path
+import re
 
 import pytest
 
@@ -175,6 +176,101 @@ def install_repo_only_search_first_mocks(
     monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
     monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+
+def make_search_payload(
+    nodes: list[dict],
+    *,
+    has_next_page: bool = False,
+    end_cursor: str | None = None,
+) -> dict:
+    return {
+        "data": {
+            "search": {
+                "nodes": nodes,
+                "pageInfo": {
+                    "hasNextPage": has_next_page,
+                    "endCursor": end_cursor,
+                },
+            },
+        },
+    }
+
+
+def _graphql_query_arg(args: tuple[str, ...]) -> str:
+    return next(arg.split("=", 1)[1] for arg in args if arg.startswith("query="))
+
+
+def _graphql_form_arg(args: tuple[str, ...], name: str) -> str | None:
+    for index, arg in enumerate(args):
+        if arg == "-F" and index + 1 < len(args) and args[index + 1].startswith(f"{name}="):
+            return args[index + 1].split("=", 1)[1]
+    return None
+
+
+def install_search_first_cli_fixture(
+    monkeypatch,
+    *,
+    gh_user: str,
+    search_pages: dict[tuple[str, str | None], dict],
+    hydrated_nodes: dict[str, dict],
+    notifications: list[dict] | None = None,
+) -> None:
+    class FakeProcess:
+        returncode = 0
+
+        def __init__(self, stdout: bytes):
+            self.stdout = stdout
+
+        async def communicate(self):
+            return self.stdout, b""
+
+    async def fake_create_subprocess_exec(*args: str, **kwargs):
+        del kwargs
+        gh_args = args[1:]
+
+        if gh_args == ("api", "user", "--jq", ".login"):
+            return FakeProcess(f"{gh_user}\n".encode())
+
+        if gh_args[:2] == ("api", "notifications"):
+            return FakeProcess(json.dumps(notifications or []).encode())
+
+        if gh_args[:2] == ("api", "graphql"):
+            query = _graphql_query_arg(gh_args)
+            if "search(type: ISSUE" in query:
+                search_query = _graphql_form_arg(gh_args, "query")
+                after = _graphql_form_arg(gh_args, "after")
+                payload = search_pages.get((search_query or "", after))
+                if payload is None:
+                    raise AssertionError(f"Unexpected search query: {search_query!r} after={after!r}")
+                return FakeProcess(json.dumps(payload).encode())
+
+            node_ids = re.findall(r'node\(id:\s*"([^"]+)"\)', query)
+            if node_ids:
+                payload = {
+                    "data": {
+                        f"n{index}": hydrated_nodes.get(node_id)
+                        for index, node_id in enumerate(node_ids)
+                    },
+                }
+                return FakeProcess(json.dumps(payload).encode())
+
+        raise AssertionError(f"Unexpected gh call: {gh_args}")
+
+    monkeypatch.setattr("agendum.gh.asyncio.create_subprocess_exec", fake_create_subprocess_exec)
+
+
+def parse_github_api_usage(caplog) -> dict[str, int]:
+    pattern = re.compile(
+        r"GitHub API usage: total=(?P<total>\d+) graphql=(?P<graphql>\d+) "
+        r"search=(?P<search>\d+) hydrate=(?P<hydrate>\d+) notifications=(?P<notifications>\d+) "
+        r"rest=(?P<rest>\d+) bytes=(?P<bytes>\d+)"
+    )
+    for record in reversed(caplog.records):
+        match = pattern.search(record.message)
+        if match:
+            return {key: int(value) for key, value in match.groupdict().items()}
+    raise AssertionError("GitHub API usage log line not found")
 
 
 def test_diff_detects_new_task() -> None:
@@ -557,6 +653,196 @@ async def test_run_sync_keeps_workspace_gh_config_dir_when_global_changes(
         in record.message
         for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_run_sync_mixed_workspace_captures_api_budget_and_expected_tasks(
+    tmp_db: Path,
+    monkeypatch,
+    caplog,
+) -> None:
+    init_db(tmp_db)
+    caplog.set_level(logging.INFO)
+
+    authored_one_url = "https://github.com/example-org/authored-repo/pull/1"
+    authored_two_url = "https://github.com/example-org/authored-repo/pull/2"
+    authored_three_url = "https://github.com/example-org/authored-repo/pull/3"
+    issue_url = "https://github.com/example-org/issue-repo/issues/11"
+    review_url = "https://github.com/example-org/review-repo/pull/7"
+
+    install_search_first_cli_fixture(
+        monkeypatch,
+        gh_user="dan",
+        search_pages={
+            ("org:example-org is:open is:pr author:dan", None): make_search_payload(
+                [
+                    {"id": "PR_AUTH_1", "repository": {"nameWithOwner": "example-org/authored-repo"}},
+                    {"id": "PR_AUTH_2", "repository": {"nameWithOwner": "example-org/authored-repo"}},
+                ],
+                has_next_page=True,
+                end_cursor="AUTH_CURSOR",
+            ),
+            ("org:example-org is:open is:pr author:dan", "AUTH_CURSOR"): make_search_payload(
+                [
+                    {"id": "PR_AUTH_2", "repository": {"nameWithOwner": "example-org/authored-repo"}},
+                    {"id": "PR_AUTH_3", "repository": {"nameWithOwner": "example-org/authored-repo"}},
+                ],
+            ),
+            ("org:example-org is:merged is:pr author:dan", None): make_search_payload([]),
+            ("org:example-org is:closed -is:merged is:pr author:dan", None): make_search_payload([]),
+            ("org:example-org is:open is:issue assignee:dan", None): make_search_payload(
+                [{"id": "ISSUE_1", "repository": {"nameWithOwner": "example-org/issue-repo"}}],
+            ),
+            ("org:example-org is:closed is:issue assignee:dan", None): make_search_payload([]),
+            ("org:example-org is:open is:pr review-requested:dan", None): make_search_payload(
+                [{"id": "PR_REVIEW_1", "repository": {"nameWithOwner": "example-org/review-repo"}}],
+            ),
+        },
+        hydrated_nodes={
+            "PR_AUTH_1": {
+                **make_authored_pr(gh_user="dan", url=authored_one_url),
+                "id": "PR_AUTH_1",
+                "number": 1,
+                "title": "Authored One",
+                "repository": {"nameWithOwner": "example-org/authored-repo"},
+                "timelineItems": {"nodes": []},
+            },
+            "PR_AUTH_2": {
+                **make_authored_pr(gh_user="dan", url=authored_two_url),
+                "id": "PR_AUTH_2",
+                "number": 2,
+                "title": "Authored Two",
+                "repository": {"nameWithOwner": "example-org/authored-repo"},
+                "reviewRequests": {"totalCount": 1},
+                "timelineItems": {"nodes": []},
+            },
+            "PR_AUTH_3": {
+                **make_authored_pr(gh_user="dan", url=authored_three_url, review_decision="APPROVED"),
+                "id": "PR_AUTH_3",
+                "number": 3,
+                "title": "Authored Three",
+                "repository": {"nameWithOwner": "example-org/authored-repo"},
+                "timelineItems": {"nodes": []},
+            },
+            "ISSUE_1": {
+                "id": "ISSUE_1",
+                "number": 11,
+                "title": "Assigned issue",
+                "url": issue_url,
+                "state": "OPEN",
+                "repository": {"nameWithOwner": "example-org/issue-repo"},
+                "labels": {"nodes": [{"name": "help wanted"}]},
+                "timelineItems": {
+                    "nodes": [
+                        {
+                            "subject": {
+                                "url": "https://github.com/example-org/issue-repo/pull/99",
+                            },
+                        },
+                    ],
+                },
+            },
+            "PR_REVIEW_1": {
+                **make_authored_pr(gh_user="alice", url=review_url),
+                "id": "PR_REVIEW_1",
+                "number": 7,
+                "title": "Review me",
+                "repository": {"nameWithOwner": "example-org/review-repo"},
+                "author": {"login": "alice", "name": "Alice Example"},
+                "timelineItems": {"nodes": []},
+            },
+        },
+    )
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(orgs=["example-org"]))
+
+    tasks = {task["gh_url"]: task for task in get_active_tasks(tmp_db)}
+    api_usage = parse_github_api_usage(caplog)
+
+    assert changes == 5
+    assert attention is True
+    assert error is None
+    assert set(tasks) == {
+        authored_one_url,
+        authored_two_url,
+        authored_three_url,
+        issue_url,
+        review_url,
+    }
+    assert tasks[authored_one_url]["status"] == "open"
+    assert tasks[authored_two_url]["status"] == "awaiting review"
+    assert tasks[authored_three_url]["status"] == "approved"
+    assert tasks[issue_url]["status"] == "in progress"
+    assert tasks[review_url]["status"] == "review requested"
+    assert tasks[review_url]["gh_author_name"] == "Alice"
+    assert api_usage["total"] <= 12
+    assert api_usage["graphql"] <= 10
+    assert api_usage["search"] <= 7
+    assert api_usage["hydrate"] <= 3
+    assert api_usage["notifications"] == 1
+    assert api_usage["rest"] == 2
+    assert api_usage["bytes"] > 0
+
+
+@pytest.mark.asyncio
+async def test_run_sync_handles_page_two_item_once_with_duplicate_across_pages(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    init_db(tmp_db)
+
+    first_url = "https://github.com/example-org/example-repo/pull/1"
+    second_url = "https://github.com/example-org/example-repo/pull/2"
+
+    install_search_first_cli_fixture(
+        monkeypatch,
+        gh_user="dan",
+        search_pages={
+            ("org:example-org is:open is:pr author:dan", None): make_search_payload(
+                [{"id": "PR_1", "repository": {"nameWithOwner": "example-org/example-repo"}}],
+                has_next_page=True,
+                end_cursor="NEXT_PAGE",
+            ),
+            ("org:example-org is:open is:pr author:dan", "NEXT_PAGE"): make_search_payload(
+                [
+                    {"id": "PR_1", "repository": {"nameWithOwner": "example-org/example-repo"}},
+                    {"id": "PR_2", "repository": {"nameWithOwner": "example-org/example-repo"}},
+                ],
+            ),
+            ("org:example-org is:merged is:pr author:dan", None): make_search_payload([]),
+            ("org:example-org is:closed -is:merged is:pr author:dan", None): make_search_payload([]),
+            ("org:example-org is:open is:issue assignee:dan", None): make_search_payload([]),
+            ("org:example-org is:closed is:issue assignee:dan", None): make_search_payload([]),
+            ("org:example-org is:open is:pr review-requested:dan", None): make_search_payload([]),
+        },
+        hydrated_nodes={
+            "PR_1": {
+                **make_authored_pr(gh_user="dan", url=first_url),
+                "id": "PR_1",
+                "number": 1,
+                "title": "First PR",
+                "repository": {"nameWithOwner": "example-org/example-repo"},
+                "timelineItems": {"nodes": []},
+            },
+            "PR_2": {
+                **make_authored_pr(gh_user="dan", url=second_url),
+                "id": "PR_2",
+                "number": 2,
+                "title": "Second PR",
+                "repository": {"nameWithOwner": "example-org/example-repo"},
+                "timelineItems": {"nodes": []},
+            },
+        },
+    )
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(orgs=["example-org"]))
+
+    tasks = {task["gh_url"]: task for task in get_active_tasks(tmp_db)}
+    assert changes == 2
+    assert attention is False
+    assert error is None
+    assert set(tasks) == {first_url, second_url}
+    assert tasks[second_url]["title"] == "Second PR"
 
 
 @pytest.mark.asyncio

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -238,7 +238,7 @@ def install_search_first_cli_fixture(
         if gh_args[:2] == ("api", "graphql"):
             query = _graphql_query_arg(gh_args)
             if "search(type: ISSUE" in query:
-                search_query = _graphql_form_arg(gh_args, "query")
+                search_query = _graphql_form_arg(gh_args, "searchQuery")
                 after = _graphql_form_arg(gh_args, "after")
                 payload = search_pages.get((search_query or "", after))
                 if payload is None:

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -639,6 +639,78 @@ async def test_run_sync_preserves_notification_cursor_when_fetch_fails(
 
 
 @pytest.mark.asyncio
+async def test_run_sync_replays_notifications_after_processing_failure(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    init_db(tmp_db)
+    repo = "example-org/example-repo"
+    url = "https://github.com/example-org/example-repo/pull/12"
+    original_cursor = "2026-04-24T12:00:00+00:00"
+    task_id = add_task(
+        tmp_db,
+        title="Existing PR",
+        source="pr_authored",
+        status="open",
+        gh_url=url,
+        gh_number=12,
+        project="example-repo",
+        gh_repo=repo,
+    )
+
+    from agendum import gh, syncer as syncer_module
+    from agendum.db import set_sync_state, update_task as db_update_task
+
+    db_update_task(tmp_db, task_id, seen=1)
+    set_sync_state(tmp_db, "github_notifications_since", original_cursor)
+
+    notifications = [
+        {
+            "reason": "comment",
+            "subject": {
+                "url": "https://api.github.com/repos/example-org/example-repo/pulls/12",
+            },
+        }
+    ]
+
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="reviewer",
+        notifications=notifications,
+    )
+
+    def failing_update_task(db_path: Path, task_id: int, **kwargs) -> None:
+        if kwargs.get("seen") == 0:
+            raise RuntimeError("notification update failed")
+        db_update_task(db_path, task_id, **kwargs)
+
+    monkeypatch.setattr(syncer_module, "update_task", failing_update_task)
+
+    with pytest.raises(RuntimeError, match="notification update failed"):
+        await run_sync(tmp_db, AgendumConfig(repos=[repo]))
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert task is not None
+    assert task["seen"] == 1
+    assert get_sync_state(tmp_db, "github_notifications_since") == original_cursor
+
+    monkeypatch.setattr(syncer_module, "update_task", db_update_task)
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(repos=[repo]))
+
+    task = find_task_by_gh_url(tmp_db, url)
+    replay_cursor = get_sync_state(tmp_db, "github_notifications_since")
+    assert changes == 1
+    assert attention is True
+    assert error is None
+    assert task is not None
+    assert task["seen"] == 0
+    assert replay_cursor is not None
+    assert replay_cursor != original_cursor
+
+
+@pytest.mark.asyncio
 async def test_run_sync_creates_review_requested_pr_with_author_name(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
     repo = "example-org/example-repo"

--- a/tests/test_syncer.py
+++ b/tests/test_syncer.py
@@ -85,6 +85,92 @@ def authored_repo_payload(*, authored_prs: list[dict]) -> dict:
     }
 
 
+def install_repo_only_search_first_mocks(
+    monkeypatch,
+    *,
+    repos: list[str],
+    gh_user: str,
+    authored_open: list[dict] | None = None,
+    authored_merged: list[dict] | None = None,
+    authored_closed: list[dict] | None = None,
+    issue_open: list[dict] | None = None,
+    issue_closed: list[dict] | None = None,
+    review_open: list[dict] | None = None,
+    hydrated_pull_requests: list[dict] | None = None,
+    hydrated_issues: list[dict] | None = None,
+    notifications: list[dict] | None = None,
+) -> None:
+    from agendum import gh
+
+    owner_scope = list(dict.fromkeys(repo.split("/", 1)[0] for repo in repos))
+    pull_requests_by_id = {
+        item["id"]: item for item in (hydrated_pull_requests or []) if item.get("id")
+    }
+    issues_by_id = {
+        item["id"]: item for item in (hydrated_issues or []) if item.get("id")
+    }
+
+    async def fake_get_gh_username() -> str:
+        return gh_user
+
+    async def fake_search_authored_prs(orgs: list[str], seen_user: str) -> tuple[list[dict], bool]:
+        assert orgs == owner_scope
+        assert seen_user == gh_user
+        return list(authored_open or []), True
+
+    async def fake_search_merged_authored_prs(
+        orgs: list[str], seen_user: str,
+    ) -> tuple[list[dict], bool]:
+        assert orgs == owner_scope
+        assert seen_user == gh_user
+        return list(authored_merged or []), True
+
+    async def fake_search_closed_authored_prs(
+        orgs: list[str], seen_user: str,
+    ) -> tuple[list[dict], bool]:
+        assert orgs == owner_scope
+        assert seen_user == gh_user
+        return list(authored_closed or []), True
+
+    async def fake_search_assigned_issues(orgs: list[str], seen_user: str) -> tuple[list[dict], bool]:
+        assert orgs == owner_scope
+        assert seen_user == gh_user
+        return list(issue_open or []), True
+
+    async def fake_search_closed_issues(orgs: list[str], seen_user: str) -> tuple[list[dict], bool]:
+        assert orgs == owner_scope
+        assert seen_user == gh_user
+        return list(issue_closed or []), True
+
+    async def fake_search_review_requested_prs(
+        orgs: list[str], seen_user: str,
+    ) -> tuple[list[dict], bool]:
+        assert orgs == owner_scope
+        assert seen_user == gh_user
+        return list(review_open or []), True
+
+    async def fake_hydrate_pull_requests(node_ids: list[str]) -> tuple[list[dict], bool]:
+        return [pull_requests_by_id[node_id] for node_id in node_ids if node_id in pull_requests_by_id], True
+
+    async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
+        return [issues_by_id[node_id] for node_id in node_ids if node_id in issues_by_id], True
+
+    async def fake_fetch_notifications(seen_user: str) -> list[dict]:
+        assert seen_user == gh_user
+        return list(notifications or [])
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+
 def test_diff_detects_new_task() -> None:
     existing: list[dict] = []
     incoming = [
@@ -158,51 +244,30 @@ def test_diff_title_change_without_status_change() -> None:
 @pytest.mark.asyncio
 async def test_run_sync_marks_closed_authored_pr_closed(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Old PR", source="pr_authored", status="open", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {
-                        "nodes": [
-                            {
-                                "number": 12,
-                                "url": url,
-                                "state": "CLOSED",
-                                "author": {"login": gh_user},
-                            }
-                        ],
-                    },
-                },
-            },
-        }
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_closed=[
+            {
+                "id": "PR_12",
+                "number": 12,
+                "title": "Old PR",
+                "url": url,
+                "state": "CLOSED",
+                "repository": {"nameWithOwner": repo},
+                "labels": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -217,56 +282,30 @@ async def test_run_sync_marks_closed_authored_pr_closed(tmp_db: Path, monkeypatc
 async def test_run_sync_revives_terminal_task(tmp_db: Path, monkeypatch) -> None:
     """A previously-closed PR that reappears as open should be updated, not re-inserted."""
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/42"
     add_task(tmp_db, title="Old PR", source="pr_authored", status="closed", gh_url=url, gh_number=42)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {
-                        "nodes": [
-                            {
-                                "number": 42,
-                                "url": url,
-                                "title": "Reopened PR",
-                                "state": "OPEN",
-                                "isDraft": False,
-                                "reviewDecision": None,
-                                "reviewRequests": {"totalCount": 0},
-                                "labels": {"nodes": []},
-                                "author": {"login": "author"},
-                            }
-                        ],
-                    },
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_42", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(gh_user="author", url=url),
+                "id": "PR_42",
+                "number": 42,
+                "title": "Reopened PR",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -275,6 +314,180 @@ async def test_run_sync_revives_terminal_task(tmp_db: Path, monkeypatch) -> None
     assert task is not None
     assert task["status"] == "open"
     assert task["title"] == "Reopened PR"
+
+
+@pytest.mark.asyncio
+async def test_run_sync_org_sync_uses_search_first_helpers(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+
+    pr_hydrate_calls: list[tuple[str, ...]] = []
+    issue_hydrate_calls: list[tuple[str, ...]] = []
+    legacy_calls = {
+        "discover_repos": 0,
+        "fetch_repo_data": 0,
+        "discover_review_prs": 0,
+        "fetch_review_detail": 0,
+    }
+
+    authored_url = "https://github.com/org/authored-repo/pull/1"
+    issue_url = "https://github.com/org/issue-repo/issues/2"
+    review_url = "https://github.com/org/review-repo/pull/3"
+
+    authored_pr = {
+        **make_authored_pr(gh_user="dan", url=authored_url),
+        "id": "PR_AUTH_1",
+        "number": 1,
+        "title": "Authored PR",
+        "repository": {"nameWithOwner": "org/authored-repo"},
+        "labels": {"nodes": [{"name": "bug"}]},
+        "timelineItems": {"nodes": []},
+    }
+    review_pr = {
+        **make_authored_pr(gh_user="alice", url=review_url),
+        "id": "PR_REVIEW_1",
+        "number": 3,
+        "title": "Review PR",
+        "repository": {"nameWithOwner": "org/review-repo"},
+        "author": {"login": "alice", "name": "Alice Example"},
+        "reviewRequests": {"totalCount": 1},
+        "timelineItems": {"nodes": []},
+    }
+    issue = {
+        "id": "ISSUE_1",
+        "number": 2,
+        "title": "Assigned issue",
+        "url": issue_url,
+        "state": "OPEN",
+        "repository": {"nameWithOwner": "org/issue-repo"},
+        "labels": {"nodes": [{"name": "help wanted"}]},
+        "timelineItems": {"nodes": []},
+    }
+
+    async def fake_get_gh_username() -> str:
+        return "dan"
+
+    async def fake_search_authored_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        assert orgs == ["org"]
+        assert gh_user == "dan"
+        return [{"id": "PR_AUTH_1", "repository": {"nameWithOwner": "org/authored-repo"}}], True
+
+    async def fake_search_merged_authored_prs(
+        orgs: list[str], gh_user: str,
+    ) -> tuple[list[dict], bool]:
+        assert orgs == ["org"]
+        assert gh_user == "dan"
+        return [], True
+
+    async def fake_search_closed_authored_prs(
+        orgs: list[str], gh_user: str,
+    ) -> tuple[list[dict], bool]:
+        assert orgs == ["org"]
+        assert gh_user == "dan"
+        return [], True
+
+    async def fake_search_assigned_issues(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        assert orgs == ["org"]
+        assert gh_user == "dan"
+        return [{"id": "ISSUE_1", "repository": {"nameWithOwner": "org/issue-repo"}}], True
+
+    async def fake_search_closed_issues(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        assert orgs == ["org"]
+        assert gh_user == "dan"
+        return [], True
+
+    async def fake_search_review_requested_prs(
+        orgs: list[str], gh_user: str,
+    ) -> tuple[list[dict], bool]:
+        assert orgs == ["org"]
+        assert gh_user == "dan"
+        return [{"id": "PR_REVIEW_1", "repository": {"nameWithOwner": "org/review-repo"}}], True
+
+    async def fake_hydrate_pull_requests(node_ids: list[str]) -> tuple[list[dict], bool]:
+        pr_hydrate_calls.append(tuple(node_ids))
+        by_id = {
+            "PR_AUTH_1": authored_pr,
+            "PR_REVIEW_1": review_pr,
+        }
+        return [by_id[node_id] for node_id in node_ids], True
+
+    async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
+        issue_hydrate_calls.append(tuple(node_ids))
+        return [issue for node_id in node_ids if node_id == "ISSUE_1"], True
+
+    async def fake_discover_repos(orgs: list[str], gh_user: str) -> set[str]:
+        legacy_calls["discover_repos"] += 1
+        return {"org/legacy"}
+
+    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
+        legacy_calls["fetch_repo_data"] += 1
+        return {}
+
+    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
+        legacy_calls["discover_review_prs"] += 1
+        return [], True
+
+    async def fake_fetch_review_detail(
+        owner: str, name: str, number: int, gh_user: str,
+    ) -> dict:
+        legacy_calls["fetch_review_detail"] += 1
+        return {}
+
+    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
+    monkeypatch.setattr(gh, "discover_repos", fake_discover_repos)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_review_detail", fake_fetch_review_detail)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(orgs=["org"]))
+
+    assert changes == 3
+    assert attention is True
+    assert error is None
+    assert {node_id for call in pr_hydrate_calls for node_id in call} == {
+        "PR_AUTH_1",
+        "PR_REVIEW_1",
+    }
+    assert issue_hydrate_calls == [("ISSUE_1",)]
+    assert legacy_calls == {
+        "discover_repos": 0,
+        "fetch_repo_data": 0,
+        "discover_review_prs": 0,
+        "fetch_review_detail": 0,
+    }
+
+    authored_task = find_task_by_gh_url(tmp_db, authored_url)
+    assert authored_task is not None
+    assert authored_task["source"] == "pr_authored"
+    assert authored_task["status"] == "open"
+    assert authored_task["project"] == "authored-repo"
+
+    issue_task = find_task_by_gh_url(tmp_db, issue_url)
+    assert issue_task is not None
+    assert issue_task["source"] == "issue"
+    assert issue_task["status"] == "open"
+    assert issue_task["project"] == "issue-repo"
+
+    review_task = find_task_by_gh_url(tmp_db, review_url)
+    assert review_task is not None
+    assert review_task["source"] == "pr_review"
+    assert review_task["status"] == "review requested"
+    assert review_task["gh_author"] == "alice"
+    assert review_task["gh_author_name"] == "Alice"
+    assert review_task["project"] == "review-repo"
 
 
 @pytest.mark.asyncio
@@ -322,7 +535,14 @@ async def test_run_sync_keeps_workspace_gh_config_dir_when_global_changes(
         if args == ("api", "user", "--jq", ".login"):
             return "author\n"
         if args[:2] == ("api", "graphql"):
-            return json.dumps(authored_repo_payload(authored_prs=[]))
+            return json.dumps({
+                "data": {
+                    "search": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [],
+                    },
+                },
+            })
         if args[:2] == ("api", "notifications"):
             return "[]"
         raise AssertionError(f"Unexpected gh call: {args}")
@@ -341,76 +561,38 @@ async def test_run_sync_keeps_workspace_gh_config_dir_when_global_changes(
     assert changes == 0
     assert attention is False
     assert error is None
-    assert observed_gh_dirs == [
-        workspace_gh_dir,
-        workspace_gh_dir,
-        workspace_gh_dir,
-    ]
+    assert observed_gh_dirs
+    assert all(path == workspace_gh_dir for path in observed_gh_dirs)
 
 
 @pytest.mark.asyncio
 async def test_run_sync_creates_review_requested_pr_with_author_name(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/34"
 
-    async def fake_get_gh_username() -> str:
-        return "reviewer"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="reviewer",
+        review_open=[{"id": "PR_34", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
             {
+                **make_authored_pr(gh_user="author", url=url),
+                "id": "PR_34",
                 "number": 34,
                 "title": "Fix telemetry attributes",
-                "url": url,
-                "repository": {"nameWithOwner": "example-org/example-repo"},
-                "author": {"login": "author"},
+                "repository": {"nameWithOwner": repo},
+                "author": {"login": "author", "name": "Author Person"},
+                "reviewRequests": {"totalCount": 1},
+                "timelineItems": {"nodes": []},
             }
-        ], True
-
-    async def fake_fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "number": number,
-                        "title": "Fix telemetry attributes",
-                        "url": url,
-                        "author": {"login": "author", "name": "Author Person"},
-                        "commits": {"nodes": [{"commit": {"committedDate": "2026-04-07T20:00:00Z"}}]},
-                        "reviews": {"nodes": []},
-                    },
-                },
-            },
-        }
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_review_detail", fake_fetch_review_detail)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     tasks = get_active_tasks(tmp_db)
@@ -430,6 +612,7 @@ async def test_run_sync_flips_reviewed_back_to_re_review_when_re_requested(tmp_d
     """After user reviews, if the author re-requests them (even without new commits),
     the status should flip from 'reviewed' back to 're-review requested'."""
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/77"
 
     add_task(
@@ -446,81 +629,46 @@ async def test_run_sync_flips_reviewed_back_to_re_review_when_re_requested(tmp_d
         tags='["review"]',
     )
 
-    async def fake_get_gh_username() -> str:
-        return "reviewer"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="reviewer",
+        review_open=[{"id": "PR_77", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
             {
+                **make_authored_pr(
+                    gh_user="author",
+                    url=url,
+                    last_commit_at="2026-04-05T09:00:00Z",
+                    reviews=[
+                        {
+                            "author": {"login": "reviewer"},
+                            "submittedAt": "2026-04-06T10:00:00Z",
+                            "state": "CHANGES_REQUESTED",
+                        }
+                    ],
+                ),
+                "id": "PR_77",
                 "number": 77,
                 "title": "Fix something",
-                "url": url,
-                "repository": {"nameWithOwner": "example-org/example-repo"},
-                "author": {"login": "author"},
-            }
-        ], True
-
-    async def fake_fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "number": number,
-                        "title": "Fix something",
-                        "url": url,
-                        "author": {"login": "author", "name": "Author Person"},
-                        # Commit is OLDER than the review (simulates rebase or no-push re-request)
-                        "commits": {"nodes": [{"commit": {"committedDate": "2026-04-05T09:00:00Z"}}]},
-                        "reviews": {
-                            "nodes": [
-                                {
-                                    "author": {"login": "reviewer"},
-                                    "submittedAt": "2026-04-06T10:00:00Z",
-                                    "state": "CHANGES_REQUESTED",
-                                },
-                            ]
-                        },
-                        "timelineItems": {
-                            "nodes": [
-                                {
-                                    "createdAt": "2026-04-07T11:00:00Z",
-                                    "requestedReviewer": {"login": "reviewer"},
-                                },
-                            ]
-                        },
-                    },
+                "repository": {"nameWithOwner": repo},
+                "author": {"login": "author", "name": "Author Person"},
+                "reviewRequests": {"totalCount": 1},
+                "timelineItems": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-07T11:00:00Z",
+                            "requestedReviewer": {"login": "reviewer"},
+                        }
+                    ]
                 },
-            },
-        }
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_review_detail", fake_fetch_review_detail)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     tasks = get_active_tasks(tmp_db)
@@ -538,6 +686,7 @@ async def test_run_sync_resurrects_done_review_task_when_re_requested(
     """A review task that was auto-closed to 'done' must be resurrected and
     flagged for attention when the user is re-requested as a reviewer."""
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/88"
 
     add_task(
@@ -554,80 +703,46 @@ async def test_run_sync_resurrects_done_review_task_when_re_requested(
         tags='["review"]',
     )
 
-    async def fake_get_gh_username() -> str:
-        return "reviewer"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="reviewer",
+        review_open=[{"id": "PR_88", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
             {
+                **make_authored_pr(
+                    gh_user="author",
+                    url=url,
+                    last_commit_at="2026-04-05T09:00:00Z",
+                    reviews=[
+                        {
+                            "author": {"login": "reviewer"},
+                            "submittedAt": "2026-04-06T10:00:00Z",
+                            "state": "COMMENTED",
+                        }
+                    ],
+                ),
+                "id": "PR_88",
                 "number": 88,
                 "title": "Fix something",
-                "url": url,
-                "repository": {"nameWithOwner": "example-org/example-repo"},
-                "author": {"login": "author"},
-            }
-        ], True
-
-    async def fake_fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "number": number,
-                        "title": "Fix something",
-                        "url": url,
-                        "author": {"login": "author", "name": "Author Person"},
-                        "commits": {"nodes": [{"commit": {"committedDate": "2026-04-05T09:00:00Z"}}]},
-                        "reviews": {
-                            "nodes": [
-                                {
-                                    "author": {"login": "reviewer"},
-                                    "submittedAt": "2026-04-06T10:00:00Z",
-                                    "state": "COMMENTED",
-                                },
-                            ]
-                        },
-                        "timelineItems": {
-                            "nodes": [
-                                {
-                                    "createdAt": "2026-04-07T11:00:00Z",
-                                    "requestedReviewer": {"login": "reviewer"},
-                                },
-                            ]
-                        },
-                    },
+                "repository": {"nameWithOwner": repo},
+                "author": {"login": "author", "name": "Author Person"},
+                "reviewRequests": {"totalCount": 1},
+                "timelineItems": {
+                    "nodes": [
+                        {
+                            "createdAt": "2026-04-07T11:00:00Z",
+                            "requestedReviewer": {"login": "reviewer"},
+                        }
+                    ]
                 },
-            },
-        }
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_review_detail", fake_fetch_review_detail)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     assert error is None
@@ -650,6 +765,7 @@ async def test_run_sync_resurrects_done_review_task_without_prior_review(
     reviewed (e.g. task was closed for a different reason), resurrect it
     as 'review requested' and flag attention."""
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/99"
 
     add_task(
@@ -666,65 +782,33 @@ async def test_run_sync_resurrects_done_review_task_without_prior_review(
         tags='["review"]',
     )
 
-    async def fake_get_gh_username() -> str:
-        return "reviewer"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="reviewer",
+        review_open=[{"id": "PR_99", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
             {
+                **make_authored_pr(
+                    gh_user="author",
+                    url=url,
+                    last_commit_at="2026-04-05T09:00:00Z",
+                    reviews=[],
+                ),
+                "id": "PR_99",
                 "number": 99,
                 "title": "Fresh ask",
-                "url": url,
-                "repository": {"nameWithOwner": "example-org/example-repo"},
-                "author": {"login": "author"},
+                "repository": {"nameWithOwner": repo},
+                "author": {"login": "author", "name": "Author Person"},
+                "reviewRequests": {"totalCount": 1},
+                "timelineItems": {"nodes": []},
             }
-        ], True
-
-    async def fake_fetch_review_detail(owner: str, name: str, number: int, gh_user: str) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "pullRequest": {
-                        "number": number,
-                        "title": "Fresh ask",
-                        "url": url,
-                        "author": {"login": "author", "name": "Author Person"},
-                        "commits": {"nodes": [{"commit": {"committedDate": "2026-04-05T09:00:00Z"}}]},
-                        "reviews": {"nodes": []},  # user never reviewed
-                        "timelineItems": {"nodes": []},
-                    },
-                },
-            },
-        }
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_review_detail", fake_fetch_review_detail)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     assert error is None
@@ -740,17 +824,19 @@ async def test_run_sync_resurrects_done_review_task_without_prior_review(
 @pytest.mark.asyncio
 async def test_run_sync_sets_authored_pr_to_review_received_for_non_blocking_feedback(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="open", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return authored_repo_payload(
-            authored_prs=[
-                make_authored_pr(
-                    gh_user=gh_user,
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_12", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(
+                    gh_user="author",
                     url=url,
                     reviews=[
                         make_review(
@@ -772,25 +858,16 @@ async def test_run_sync_sets_authored_pr_to_review_received_for_non_blocking_fee
                         ),
                     ],
                 ),
-            ],
-        )
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+                "id": "PR_12",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -804,17 +881,19 @@ async def test_run_sync_sets_authored_pr_to_review_received_for_non_blocking_fee
 @pytest.mark.asyncio
 async def test_run_sync_keeps_changes_requested_for_blocking_review(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="open", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return authored_repo_payload(
-            authored_prs=[
-                make_authored_pr(
-                    gh_user=gh_user,
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_12", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(
+                    gh_user="author",
                     url=url,
                     review_decision="CHANGES_REQUESTED",
                     reviews=[
@@ -837,25 +916,16 @@ async def test_run_sync_keeps_changes_requested_for_blocking_review(tmp_db: Path
                         ),
                     ],
                 ),
-            ],
-        )
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+                "id": "PR_12",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -868,17 +938,19 @@ async def test_run_sync_keeps_changes_requested_for_blocking_review(tmp_db: Path
 @pytest.mark.asyncio
 async def test_run_sync_clears_review_received_after_author_reply(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return authored_repo_payload(
-            authored_prs=[
-                make_authored_pr(
-                    gh_user=gh_user,
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_12", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(
+                    gh_user="author",
                     url=url,
                     reviews=[
                         make_review(
@@ -901,25 +973,16 @@ async def test_run_sync_clears_review_received_after_author_reply(tmp_db: Path, 
                         ),
                     ],
                 ),
-            ],
-        )
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+                "id": "PR_12",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -932,17 +995,19 @@ async def test_run_sync_clears_review_received_after_author_reply(tmp_db: Path, 
 @pytest.mark.asyncio
 async def test_run_sync_keeps_review_received_with_sibling_thread_reply(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return authored_repo_payload(
-            authored_prs=[
-                make_authored_pr(
-                    gh_user=gh_user,
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_12", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(
+                    gh_user="author",
                     url=url,
                     reviews=[
                         make_review(
@@ -975,25 +1040,16 @@ async def test_run_sync_keeps_review_received_with_sibling_thread_reply(tmp_db: 
                         ),
                     ],
                 ),
-            ],
-        )
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+                "id": "PR_12",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -1007,17 +1063,19 @@ async def test_run_sync_keeps_review_received_with_sibling_thread_reply(tmp_db: 
 @pytest.mark.asyncio
 async def test_run_sync_keeps_review_received_when_older_review_is_unresolved(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return authored_repo_payload(
-            authored_prs=[
-                make_authored_pr(
-                    gh_user=gh_user,
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_12", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(
+                    gh_user="author",
                     url=url,
                     reviews=[
                         make_review(
@@ -1056,25 +1114,16 @@ async def test_run_sync_keeps_review_received_when_older_review_is_unresolved(tm
                         ),
                     ],
                 ),
-            ],
-        )
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+                "id": "PR_12",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -1088,17 +1137,19 @@ async def test_run_sync_keeps_review_received_when_older_review_is_unresolved(tm
 @pytest.mark.asyncio
 async def test_run_sync_clears_review_received_after_all_threads_resolved(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return authored_repo_payload(
-            authored_prs=[
-                make_authored_pr(
-                    gh_user=gh_user,
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_12", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(
+                    gh_user="author",
                     url=url,
                     reviews=[
                         make_review(
@@ -1120,25 +1171,16 @@ async def test_run_sync_clears_review_received_after_all_threads_resolved(tmp_db
                         ),
                     ],
                 ),
-            ],
-        )
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+                "id": "PR_12",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -1151,17 +1193,19 @@ async def test_run_sync_clears_review_received_after_all_threads_resolved(tmp_db
 @pytest.mark.asyncio
 async def test_run_sync_keeps_review_received_after_push_when_feedback_threads_exist(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return authored_repo_payload(
-            authored_prs=[
-                make_authored_pr(
-                    gh_user=gh_user,
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_12", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(
+                    gh_user="author",
                     url=url,
                     last_commit_at="2026-04-10T12:05:00Z",
                     reviews=[
@@ -1184,25 +1228,16 @@ async def test_run_sync_keeps_review_received_after_push_when_feedback_threads_e
                         ),
                     ],
                 ),
-            ],
-        )
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+                "id": "PR_12",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)
@@ -1215,17 +1250,19 @@ async def test_run_sync_keeps_review_received_after_push_when_feedback_threads_e
 @pytest.mark.asyncio
 async def test_run_sync_clears_review_received_after_push_without_feedback_threads(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
+    repo = "example-org/example-repo"
     url = "https://github.com/example-org/example-repo/pull/12"
     add_task(tmp_db, title="Improve sync status handling", source="pr_authored", status="review received", gh_url=url)
 
-    async def fake_get_gh_username() -> str:
-        return "author"
-
-    async def fake_fetch_repo_data(owner: str, name: str, gh_user: str) -> dict:
-        return authored_repo_payload(
-            authored_prs=[
-                make_authored_pr(
-                    gh_user=gh_user,
+    install_repo_only_search_first_mocks(
+        monkeypatch,
+        repos=[repo],
+        gh_user="author",
+        authored_open=[{"id": "PR_12", "repository": {"nameWithOwner": repo}}],
+        hydrated_pull_requests=[
+            {
+                **make_authored_pr(
+                    gh_user="author",
                     url=url,
                     last_commit_at="2026-04-10T12:05:00Z",
                     reviews=[
@@ -1237,25 +1274,16 @@ async def test_run_sync_clears_review_received_after_push_without_feedback_threa
                     ],
                     review_threads=[],
                 ),
-            ],
-        )
-
-    async def fake_discover_review_prs(orgs: list[str], gh_user: str) -> tuple[list[dict], bool]:
-        return [], True
-
-    async def fake_fetch_notifications(gh_user: str) -> list[dict]:
-        return []
-
-    from agendum import gh
-
-    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
-    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+                "id": "PR_12",
+                "repository": {"nameWithOwner": repo},
+                "timelineItems": {"nodes": []},
+            }
+        ],
+    )
 
     changes, attention, error = await run_sync(
         tmp_db,
-        AgendumConfig(repos=["example-org/example-repo"]),
+        AgendumConfig(repos=[repo]),
     )
 
     task = find_task_by_gh_url(tmp_db, url)

--- a/tests/test_syncer_edge_cases.py
+++ b/tests/test_syncer_edge_cases.py
@@ -163,13 +163,14 @@ async def test_run_sync_notification_marks_seen_task_unseen(
     async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
         return [{
             "reason": "comment",
             "subject": {
                 "url": "https://api.github.com/repos/org/repo/pulls/5",
             },
-        }]
+        }], True
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
@@ -246,8 +247,9 @@ async def test_run_sync_excludes_repos(tmp_db: Path, monkeypatch) -> None:
     async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
@@ -325,8 +327,9 @@ async def test_run_sync_repo_only_excludes_repos(tmp_db: Path, monkeypatch) -> N
     async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
@@ -405,8 +408,9 @@ async def test_run_sync_attention_on_status_change_to_approved(
     async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
@@ -455,8 +459,6 @@ async def test_run_sync_org_sync_incomplete_slice_keeps_existing_task(
         "search_assigned_issues": 0,
         "hydrate_pull_requests": 0,
         "hydrate_issues": 0,
-        "discover_repos": 0,
-        "fetch_repo_data": 0,
     }
 
     async def fake_get_gh_username() -> str:
@@ -494,19 +496,9 @@ async def test_run_sync_org_sync_incomplete_slice_keeps_existing_task(
         calls["hydrate_issues"] += 1
         return [], False
 
-    async def fake_discover_repos(orgs, gh_user) -> set:
-        calls["discover_repos"] += 1
-        return {repo}
-
-    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        calls["fetch_repo_data"] += 1
-        return make_empty_repo_payload()
-
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
         return [], True
-
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
 
     from agendum import gh
 
@@ -519,9 +511,6 @@ async def test_run_sync_org_sync_incomplete_slice_keeps_existing_task(
     monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
     monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
     monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
-    monkeypatch.setattr(gh, "discover_repos", fake_discover_repos)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(tmp_db, AgendumConfig(orgs=["org"]))
@@ -533,8 +522,6 @@ async def test_run_sync_org_sync_incomplete_slice_keeps_existing_task(
     assert calls["search_assigned_issues"] == 1
     if source == "issue":
         assert calls["hydrate_issues"] == 1
-    assert calls["discover_repos"] == 0
-    assert calls["fetch_repo_data"] == 0
 
     task = find_task_by_gh_url(tmp_db, url)
     assert task is not None
@@ -578,8 +565,9 @@ async def test_run_sync_preserves_tasks_when_repo_search_is_incomplete(
     async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
@@ -638,8 +626,9 @@ async def test_run_sync_preserves_review_tasks_when_review_fetch_fails(
     async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
@@ -714,8 +703,9 @@ async def test_run_sync_preserves_review_tasks_when_review_detail_fetch_fails(
     async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
 
@@ -749,10 +739,6 @@ async def test_run_sync_repo_only_uses_search_first_path(
 ) -> None:
     init_db(tmp_db)
 
-    legacy_calls = {
-        "fetch_repo_data": 0,
-        "discover_review_prs": 0,
-    }
     search_calls = {
         "search_authored_prs": 0,
         "search_merged_authored_prs": 0,
@@ -833,16 +819,9 @@ async def test_run_sync_repo_only_uses_search_first_path(
             "repository": {"nameWithOwner": "org/repo"},
         }], True
 
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
-        legacy_calls["discover_review_prs"] += 1
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
         return [], True
-
-    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        legacy_calls["fetch_repo_data"] += 1
-        return {}
-
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
 
     from agendum import gh
 
@@ -855,8 +834,6 @@ async def test_run_sync_repo_only_uses_search_first_path(
     monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
     monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
     monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(tmp_db, AgendumConfig(repos=["org/repo"]))
@@ -864,10 +841,6 @@ async def test_run_sync_repo_only_uses_search_first_path(
     assert changes == 2
     assert attention is False
     assert error is None
-    assert legacy_calls == {
-        "fetch_repo_data": 0,
-        "discover_review_prs": 0,
-    }
     assert search_calls == {
         "search_authored_prs": 1,
         "search_merged_authored_prs": 1,
@@ -930,8 +903,9 @@ async def test_run_sync_repo_only_preserves_review_tasks_on_incomplete_review_se
     async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
 
@@ -992,8 +966,9 @@ async def test_run_sync_closes_review_pr_as_done(
     async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
@@ -1018,11 +993,11 @@ async def test_run_sync_closes_review_pr_as_done(
 async def test_run_sync_closes_review_pr_when_repo_not_in_fetched_repos(
     tmp_db: Path, monkeypatch,
 ) -> None:
-    """Review task closes even when the repo drops out of discover_repos.
+    """Review task closes even when its repo is not in fetched_repos.
 
-    Once the user reviews, GitHub removes them from --review-requested, so
-    the repo is no longer surfaced by discover_repos and never makes it
-    into fetched_repos. The review task must still close.
+    Once the user reviews, GitHub removes them from the review-requested
+    search results, so the repo may never land in fetched_repos. The
+    review task must still close.
     """
     init_db(tmp_db)
     url = "https://github.com/org/other-repo/pull/100"
@@ -1057,8 +1032,9 @@ async def test_run_sync_closes_review_pr_when_repo_not_in_fetched_repos(
     async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
         return [], True
 
-    async def fake_fetch_notifications(gh_user) -> list:
-        return []
+    async def fake_fetch_notifications(gh_user, *, since: str | None = None) -> tuple[list, bool]:
+        del gh_user, since
+        return [], True
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)

--- a/tests/test_syncer_edge_cases.py
+++ b/tests/test_syncer_edge_cases.py
@@ -9,6 +9,21 @@ from agendum.db import add_task, find_task_by_gh_url, get_active_tasks, init_db,
 from agendum.syncer import diff_tasks, run_sync
 
 
+def make_empty_repo_payload() -> dict:
+    return {
+        "data": {
+            "repository": {
+                "isArchived": False,
+                "openIssues": {"nodes": []},
+                "closedIssues": {"nodes": []},
+                "authoredPRs": {"nodes": []},
+                "mergedPRs": {"nodes": []},
+                "closedPRs": {"nodes": []},
+            },
+        },
+    }
+
+
 # ── diff edge cases ──────────────────────────────────────────────────────
 
 
@@ -107,30 +122,45 @@ async def test_run_sync_notification_marks_seen_task_unseen(
     async def fake_get_gh_username() -> str:
         return "author"
 
-    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {
-                        "nodes": [{
-                            "number": 5, "url": url, "title": "Existing PR",
-                            "state": "OPEN", "isDraft": False,
-                            "reviewDecision": None,
-                            "reviewRequests": {"totalCount": 0},
-                            "labels": {"nodes": []},
-                            "author": {"login": "author"},
-                        }],
-                    },
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [{"id": "PR_5", "repository": {"nameWithOwner": "org/repo"}}], True
 
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids) -> tuple[list, bool]:
+        assert node_ids == ["PR_5"]
+        return [{
+            "id": "PR_5",
+            "number": 5,
+            "url": url,
+            "title": "Existing PR",
+            "state": "OPEN",
+            "isDraft": False,
+            "reviewDecision": None,
+            "reviewRequests": {"totalCount": 0},
+            "labels": {"nodes": []},
+            "author": {"login": "author"},
+            "repository": {"nameWithOwner": "org/repo"},
+            "commits": {"nodes": []},
+            "reviews": {"nodes": []},
+            "reviewThreads": {"nodes": []},
+        }], True
+
+    async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
@@ -143,8 +173,14 @@ async def test_run_sync_notification_marks_seen_task_unseen(
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(
@@ -160,30 +196,54 @@ async def test_run_sync_notification_marks_seen_task_unseen(
 async def test_run_sync_excludes_repos(tmp_db: Path, monkeypatch) -> None:
     init_db(tmp_db)
 
-    fetch_calls = []
+    hydrate_calls: list[tuple[str, ...]] = []
 
     async def fake_get_gh_username() -> str:
         return "author"
 
-    async def fake_discover_repos(orgs, gh_user) -> set:
-        return {"org/keep", "org/exclude-me"}
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [
+            {"id": "PR_KEEP", "repository": {"nameWithOwner": "org/keep"}},
+            {"id": "PR_SKIP", "repository": {"nameWithOwner": "org/exclude-me"}},
+        ], True
 
-    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        fetch_calls.append(f"{owner}/{name}")
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
 
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids: list[str]) -> tuple[list[dict], bool]:
+        hydrate_calls.append(tuple(node_ids))
+        return [
+            {
+                "id": "PR_KEEP",
+                "number": 1,
+                "title": "Keep PR",
+                "url": "https://github.com/org/keep/pull/1",
+                "state": "OPEN",
+                "isDraft": False,
+                "reviewDecision": None,
+                "repository": {"nameWithOwner": "org/keep"},
+                "labels": {"nodes": []},
+                "reviewRequests": {"totalCount": 0},
+                "commits": {"nodes": []},
+                "reviews": {"nodes": []},
+                "reviewThreads": {"nodes": []},
+                "author": {"login": "author"},
+            }
+        ], True
+
+    async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
         return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
@@ -191,9 +251,14 @@ async def test_run_sync_excludes_repos(tmp_db: Path, monkeypatch) -> None:
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "discover_repos", fake_discover_repos)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     await run_sync(
@@ -201,8 +266,91 @@ async def test_run_sync_excludes_repos(tmp_db: Path, monkeypatch) -> None:
         AgendumConfig(orgs=["org"], exclude_repos=["org/exclude-me"]),
     )
 
-    assert "org/keep" in fetch_calls
-    assert "org/exclude-me" not in fetch_calls
+    assert hydrate_calls == [("PR_KEEP",)]
+    assert find_task_by_gh_url(tmp_db, "https://github.com/org/keep/pull/1") is not None
+    assert find_task_by_gh_url(tmp_db, "https://github.com/org/exclude-me/pull/1") is None
+
+
+async def test_run_sync_repo_only_excludes_repos(tmp_db: Path, monkeypatch) -> None:
+    init_db(tmp_db)
+
+    hydrate_calls: list[tuple[str, ...]] = []
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [
+            {"id": "PR_KEEP", "repository": {"nameWithOwner": "org/keep"}},
+            {"id": "PR_SKIP", "repository": {"nameWithOwner": "org/exclude-me"}},
+        ], True
+
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids: list[str]) -> tuple[list[dict], bool]:
+        hydrate_calls.append(tuple(node_ids))
+        return [
+            {
+                "id": "PR_KEEP",
+                "number": 1,
+                "title": "Keep PR",
+                "url": "https://github.com/org/keep/pull/1",
+                "state": "OPEN",
+                "isDraft": False,
+                "reviewDecision": None,
+                "repository": {"nameWithOwner": "org/keep"},
+                "labels": {"nodes": []},
+                "reviewRequests": {"totalCount": 0},
+                "commits": {"nodes": []},
+                "reviews": {"nodes": []},
+                "reviewThreads": {"nodes": []},
+                "author": {"login": "author"},
+            }
+        ], True
+
+    async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
+        return [], True
+
+    async def fake_fetch_notifications(gh_user) -> list:
+        return []
+
+    from agendum import gh
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    await run_sync(
+        tmp_db,
+        AgendumConfig(
+            repos=["org/keep", "org/exclude-me"],
+            exclude_repos=["org/exclude-me"],
+        ),
+    )
+
+    assert hydrate_calls == [("PR_KEEP",)]
+    assert find_task_by_gh_url(tmp_db, "https://github.com/org/keep/pull/1") is not None
+    assert find_task_by_gh_url(tmp_db, "https://github.com/org/exclude-me/pull/1") is None
 
 
 async def test_run_sync_attention_on_status_change_to_approved(
@@ -216,30 +364,45 @@ async def test_run_sync_attention_on_status_change_to_approved(
     async def fake_get_gh_username() -> str:
         return "author"
 
-    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {
-                        "nodes": [{
-                            "number": 10, "url": url, "title": "My PR",
-                            "state": "OPEN", "isDraft": False,
-                            "reviewDecision": "APPROVED",
-                            "reviewRequests": {"totalCount": 1},
-                            "labels": {"nodes": []},
-                            "author": {"login": "author"},
-                        }],
-                    },
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [{"id": "PR_10", "repository": {"nameWithOwner": "org/repo"}}], True
 
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids) -> tuple[list, bool]:
+        assert node_ids == ["PR_10"]
+        return [{
+            "id": "PR_10",
+            "number": 10,
+            "url": url,
+            "title": "My PR",
+            "state": "OPEN",
+            "isDraft": False,
+            "reviewDecision": "APPROVED",
+            "reviewRequests": {"totalCount": 1},
+            "labels": {"nodes": []},
+            "author": {"login": "author"},
+            "repository": {"nameWithOwner": "org/repo"},
+            "commits": {"nodes": []},
+            "reviews": {"nodes": []},
+            "reviewThreads": {"nodes": []},
+        }], True
+
+    async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
@@ -247,8 +410,14 @@ async def test_run_sync_attention_on_status_change_to_approved(
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(
@@ -261,21 +430,77 @@ async def test_run_sync_attention_on_status_change_to_approved(
     assert task["status"] == "approved"
 
 
-async def test_run_sync_preserves_tasks_when_repo_fetch_fails(
-    tmp_db: Path, monkeypatch,
+@pytest.mark.parametrize(
+    ("source", "url", "repo"),
+    [
+        ("pr_authored", "https://github.com/org/authored-repo/pull/7",
+         "org/authored-repo"),
+        ("issue", "https://github.com/org/issue-repo/issues/8",
+         "org/issue-repo"),
+    ],
+)
+async def test_run_sync_org_sync_incomplete_slice_keeps_existing_task(
+    tmp_db: Path,
+    monkeypatch,
+    source: str,
+    url: str,
+    repo: str,
 ) -> None:
-    """Tasks should survive when their repo's API call fails."""
     init_db(tmp_db)
-    url = "https://github.com/org/repo/pull/3"
-    add_task(tmp_db, title="My PR", source="pr_authored", status="open",
-             gh_url=url, gh_repo="org/repo")
+    add_task(tmp_db, title="Existing task", source=source, status="open",
+             gh_url=url, gh_repo=repo)
+
+    calls = {
+        "search_authored_prs": 0,
+        "search_assigned_issues": 0,
+        "hydrate_pull_requests": 0,
+        "hydrate_issues": 0,
+        "discover_repos": 0,
+        "fetch_repo_data": 0,
+    }
 
     async def fake_get_gh_username() -> str:
-        return "author"
+        return "dan"
+
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        calls["search_authored_prs"] += 1
+        if source == "pr_authored":
+            return [], False
+        return [], True
+
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        calls["search_assigned_issues"] += 1
+        if source == "issue":
+            return [{"id": "ISSUE_1", "repository": {"nameWithOwner": repo}}], True
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids) -> tuple[list, bool]:
+        calls["hydrate_pull_requests"] += 1
+        return [], False
+
+    async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
+        calls["hydrate_issues"] += 1
+        return [], False
+
+    async def fake_discover_repos(orgs, gh_user) -> set:
+        calls["discover_repos"] += 1
+        return {repo}
 
     async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        # Simulate API failure — returns empty
-        return {}
+        calls["fetch_repo_data"] += 1
+        return make_empty_repo_payload()
 
     async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
         return [], True
@@ -284,9 +509,88 @@ async def test_run_sync_preserves_tasks_when_repo_fetch_fails(
         return []
 
     from agendum import gh
+
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
+    monkeypatch.setattr(gh, "discover_repos", fake_discover_repos)
     monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
     monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(orgs=["org"]))
+
+    assert changes == 0
+    assert attention is False
+    assert error is None
+    assert calls["search_authored_prs"] == 1
+    assert calls["search_assigned_issues"] == 1
+    if source == "issue":
+        assert calls["hydrate_issues"] == 1
+    assert calls["discover_repos"] == 0
+    assert calls["fetch_repo_data"] == 0
+
+    task = find_task_by_gh_url(tmp_db, url)
+    assert task is not None
+    assert task["status"] == "open"
+
+
+async def test_run_sync_preserves_tasks_when_repo_search_is_incomplete(
+    tmp_db: Path, monkeypatch,
+) -> None:
+    """Tasks should survive when repo-scoped search-first discovery is incomplete."""
+    init_db(tmp_db)
+    url = "https://github.com/org/repo/pull/3"
+    add_task(tmp_db, title="My PR", source="pr_authored", status="open",
+             gh_url=url, gh_repo="org/repo")
+
+    async def fake_get_gh_username() -> str:
+        return "author"
+
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [], False
+
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_fetch_notifications(gh_user) -> list:
+        return []
+
+    from agendum import gh
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(
@@ -301,7 +605,7 @@ async def test_run_sync_preserves_tasks_when_repo_fetch_fails(
 async def test_run_sync_preserves_review_tasks_when_review_fetch_fails(
     tmp_db: Path, monkeypatch,
 ) -> None:
-    """Review tasks should survive when discover_review_prs fails."""
+    """Review tasks should survive when review search-first discovery fails."""
     init_db(tmp_db)
     url = "https://github.com/org/repo/pull/9"
     add_task(tmp_db, title="Review PR", source="pr_review", status="review requested",
@@ -310,30 +614,43 @@ async def test_run_sync_preserves_review_tasks_when_review_fetch_fails(
     async def fake_get_gh_username() -> str:
         return "reviewer"
 
-    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
 
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
         return [], False  # Simulate API failure
+
+    async def fake_hydrate_pull_requests(node_ids) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
+        return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
         return []
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(
@@ -345,7 +662,227 @@ async def test_run_sync_preserves_review_tasks_when_review_fetch_fails(
     assert task["status"] == "review requested", "Review task should not be closed when review fetch failed"
 
 
-async def test_run_sync_repo_only_preserves_review_tasks_without_review_discovery(
+async def test_run_sync_preserves_review_tasks_when_review_detail_fetch_fails(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    init_db(tmp_db)
+    url = "https://github.com/org/repo/pull/12"
+    add_task(
+        tmp_db,
+        title="Review PR",
+        source="pr_review",
+        status="review requested",
+        gh_url=url,
+        gh_repo="org/repo",
+    )
+
+    async def fake_get_gh_username() -> str:
+        return "reviewer"
+
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [
+            {
+                "id": "PR_12",
+                "number": 12,
+                "title": "Review PR",
+                "url": url,
+                "repository": {"nameWithOwner": "org/repo"},
+                "author": {"login": "author"},
+            }
+        ], True
+
+    async def fake_hydrate_pull_requests(node_ids) -> tuple[list, bool]:
+        assert node_ids == ["PR_12"]
+        return [], False
+
+    async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_fetch_notifications(gh_user) -> list:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(
+        tmp_db,
+        AgendumConfig(orgs=["org"], repos=["org/repo"]),
+    )
+
+    assert changes == 0
+    assert attention is False
+    assert error is None
+    task = find_task_by_gh_url(tmp_db, url)
+    assert task is not None
+    assert task["status"] == "review requested"
+
+
+async def test_run_sync_repo_only_uses_search_first_path(
+    tmp_db: Path,
+    monkeypatch,
+) -> None:
+    init_db(tmp_db)
+
+    legacy_calls = {
+        "fetch_repo_data": 0,
+        "discover_review_prs": 0,
+    }
+    search_calls = {
+        "search_authored_prs": 0,
+        "search_merged_authored_prs": 0,
+        "search_closed_authored_prs": 0,
+        "search_assigned_issues": 0,
+        "search_closed_issues": 0,
+        "search_review_requested_prs": 0,
+        "hydrate_pull_requests": 0,
+        "hydrate_issues": 0,
+    }
+    authored_url = "https://github.com/org/repo/pull/1"
+    issue_url = "https://github.com/org/repo/issues/2"
+
+    async def fake_get_gh_username() -> str:
+        return "dan"
+
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        search_calls["search_authored_prs"] += 1
+        assert orgs == ["org"]
+        return [{"id": "PR_1", "repository": {"nameWithOwner": "org/repo"}}], True
+
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        search_calls["search_merged_authored_prs"] += 1
+        assert orgs == ["org"]
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        search_calls["search_closed_authored_prs"] += 1
+        assert orgs == ["org"]
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        search_calls["search_assigned_issues"] += 1
+        assert orgs == ["org"]
+        return [{"id": "ISSUE_2", "repository": {"nameWithOwner": "org/repo"}}], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        search_calls["search_closed_issues"] += 1
+        assert orgs == ["org"]
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        search_calls["search_review_requested_prs"] += 1
+        assert orgs == ["org"]
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids) -> tuple[list, bool]:
+        search_calls["hydrate_pull_requests"] += 1
+        assert node_ids == ["PR_1"]
+        return [{
+            "id": "PR_1",
+            "number": 1,
+            "title": "Repo PR",
+            "url": authored_url,
+            "state": "OPEN",
+            "isDraft": False,
+            "reviewDecision": None,
+            "reviewRequests": {"totalCount": 0},
+            "labels": {"nodes": []},
+            "author": {"login": "dan"},
+            "repository": {"nameWithOwner": "org/repo"},
+            "commits": {"nodes": []},
+            "reviews": {"nodes": []},
+            "reviewThreads": {"nodes": []},
+        }], True
+
+    async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
+        search_calls["hydrate_issues"] += 1
+        assert node_ids == ["ISSUE_2"]
+        return [{
+            "id": "ISSUE_2",
+            "number": 2,
+            "title": "Repo issue",
+            "url": issue_url,
+            "state": "OPEN",
+            "labels": {"nodes": []},
+            "timelineItems": {"nodes": []},
+            "repository": {"nameWithOwner": "org/repo"},
+        }], True
+
+    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+        legacy_calls["discover_review_prs"] += 1
+        return [], True
+
+    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
+        legacy_calls["fetch_repo_data"] += 1
+        return {}
+
+    async def fake_fetch_notifications(gh_user) -> list:
+        return []
+
+    from agendum import gh
+
+    monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
+    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
+    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
+
+    changes, attention, error = await run_sync(tmp_db, AgendumConfig(repos=["org/repo"]))
+
+    assert changes == 2
+    assert attention is False
+    assert error is None
+    assert legacy_calls == {
+        "fetch_repo_data": 0,
+        "discover_review_prs": 0,
+    }
+    assert search_calls == {
+        "search_authored_prs": 1,
+        "search_merged_authored_prs": 1,
+        "search_closed_authored_prs": 1,
+        "search_assigned_issues": 1,
+        "search_closed_issues": 1,
+        "search_review_requested_prs": 1,
+        "hydrate_pull_requests": 1,
+        "hydrate_issues": 1,
+    }
+    assert find_task_by_gh_url(tmp_db, authored_url)["source"] == "pr_authored"
+    assert find_task_by_gh_url(tmp_db, issue_url)["source"] == "issue"
+
+
+async def test_run_sync_repo_only_preserves_review_tasks_on_incomplete_review_search(
     tmp_db: Path,
     monkeypatch,
 ) -> None:
@@ -363,22 +900,34 @@ async def test_run_sync_repo_only_preserves_review_tasks_without_review_discover
     async def fake_get_gh_username() -> str:
         return "reviewer"
 
-    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [], True
 
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
-        assert orgs == []
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        assert orgs == ["org"]
+        return [], False
+
+    async def fake_hydrate_pull_requests(node_ids) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_issues(node_ids) -> tuple[list, bool]:
         return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
@@ -387,8 +936,14 @@ async def test_run_sync_repo_only_preserves_review_tasks_without_review_discover
     from agendum import gh
 
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(tmp_db, AgendumConfig(repos=["org/repo"]))
@@ -413,21 +968,28 @@ async def test_run_sync_closes_review_pr_as_done(
     async def fake_get_gh_username() -> str:
         return "reviewer"
 
-    async def fake_fetch_repo_data(owner, name, gh_user) -> dict:
-        return {
-            "data": {
-                "repository": {
-                    "isArchived": False,
-                    "openIssues": {"nodes": []},
-                    "closedIssues": {"nodes": []},
-                    "authoredPRs": {"nodes": []},
-                    "mergedPRs": {"nodes": []},
-                    "closedPRs": {"nodes": []},
-                },
-            },
-        }
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
 
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids: list[str]) -> tuple[list[dict], bool]:
+        return [], True
+
+    async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
         return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
@@ -435,8 +997,14 @@ async def test_run_sync_closes_review_pr_as_done(
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "fetch_repo_data", fake_fetch_repo_data)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(
@@ -465,10 +1033,28 @@ async def test_run_sync_closes_review_pr_when_repo_not_in_fetched_repos(
     async def fake_get_gh_username() -> str:
         return "reviewer"
 
-    async def fake_discover_repos(orgs, gh_user) -> set:
-        return set()
+    async def fake_search_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
 
-    async def fake_discover_review_prs(orgs, gh_user) -> tuple[list, bool]:
+    async def fake_search_merged_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_authored_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_assigned_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_closed_issues(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_search_review_requested_prs(orgs, gh_user) -> tuple[list, bool]:
+        return [], True
+
+    async def fake_hydrate_pull_requests(node_ids: list[str]) -> tuple[list[dict], bool]:
+        return [], True
+
+    async def fake_hydrate_issues(node_ids: list[str]) -> tuple[list[dict], bool]:
         return [], True
 
     async def fake_fetch_notifications(gh_user) -> list:
@@ -476,8 +1062,14 @@ async def test_run_sync_closes_review_pr_when_repo_not_in_fetched_repos(
 
     from agendum import gh
     monkeypatch.setattr(gh, "get_gh_username", fake_get_gh_username)
-    monkeypatch.setattr(gh, "discover_repos", fake_discover_repos)
-    monkeypatch.setattr(gh, "discover_review_prs", fake_discover_review_prs)
+    monkeypatch.setattr(gh, "search_authored_prs", fake_search_authored_prs)
+    monkeypatch.setattr(gh, "search_merged_authored_prs", fake_search_merged_authored_prs)
+    monkeypatch.setattr(gh, "search_closed_authored_prs", fake_search_closed_authored_prs)
+    monkeypatch.setattr(gh, "search_assigned_issues", fake_search_assigned_issues)
+    monkeypatch.setattr(gh, "search_closed_issues", fake_search_closed_issues)
+    monkeypatch.setattr(gh, "search_review_requested_prs", fake_search_review_requested_prs)
+    monkeypatch.setattr(gh, "hydrate_pull_requests", fake_hydrate_pull_requests)
+    monkeypatch.setattr(gh, "hydrate_issues", fake_hydrate_issues)
     monkeypatch.setattr(gh, "fetch_notifications", fake_fetch_notifications)
 
     changes, attention, error = await run_sync(tmp_db, AgendumConfig(orgs=["org"]))

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "agendum"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "mcp", extra = ["cli"] },


### PR DESCRIPTION
closes #49

## Summary
- add GitHub search and batched hydration primitives for authored PRs, assigned issues, closed states, and review requests
- add bulk DB URL lookup support for sync reconciliation and notification handling
- move both org-scoped and repo-whitelisted workspaces onto the same search-first sync path with incomplete-data close suppression
- finish the issue-49 follow-ups with incremental notification polling, legacy repo-fanout removal, and lightweight GitHub API-budget instrumentation

## Status Review
- the main repo-fanout sync path has been removed from `run_sync` along with the old repo-centric GitHub helpers
- repo-only workspaces derive owner scope from `config.repos` and use the same search-first collector as org workspaces
- close safety is preserved: incomplete authored / issue discovery suppresses unsafe closes, and incomplete review discovery suppresses review-task closes
- notification polling is now incremental via persisted `github_notifications_since` sync metadata instead of a full unread fetch each sync
- lightweight `gh` call recording now makes search, hydrate, notification, REST/GraphQL, and payload-byte budget regressions visible in tests and sync logs
- `gh_node_id` persistence is explicitly deferred; the current search-first design still reconciles on `gh_url` and does not require persisted node IDs
- focused verification passed: `uv run pytest tests/test_db.py tests/test_db_edge_cases.py tests/test_gh.py tests/test_gh_edge_cases.py tests/test_syncer.py tests/test_syncer_edge_cases.py`

## Remaining Work
- none in scope for this PR
- follow-up only if needed later: persist `gh_node_id` if a future hydration / reconciliation design needs stable cross-sync node lookups

## Notes
- `uv.lock` was kept unchanged despite `uv run` temporarily bumping the editable package version locally during verification
